### PR TITLE
[#39] 좌석관리 뷰 UI 구현 및 메인피쳐 플로우와 연결

### DIFF
--- a/SeatCatcher/SeatCatcher/Sources/App/Coordinator/AppCoordinator.swift
+++ b/SeatCatcher/SeatCatcher/Sources/App/Coordinator/AppCoordinator.swift
@@ -34,6 +34,7 @@ final class AppCoordinator: Coordinator {
         self.diContainer = diContainer
     }
 
+    @MainActor
     @ViewBuilder
     func buildScene(_ scene: AppScene) -> some View {
         switch scene {
@@ -64,6 +65,49 @@ final class AppCoordinator: Coordinator {
             SelectPathView(viewModel: selectPathViewModel)
         case .searchStations(let viewModel):
             SearchStationsView(viewModel: viewModel)
+        case .mainFeature(let hasSeated):
+            let viewModel = MainFeatureViewModel(
+                store: diContainer.resolveAppStore(),
+                coordinator: self,
+                getSeatInSectionUseCase: diContainer.resolveGetSeatInSectionUseCase(),
+                unlockSeatUseCase: diContainer.resolveUnlockSeatUseCase(),
+                userStatus: hasSeated ? .seated : .standing
+            )
+            MainFeatureView(viewModel: viewModel)
+        case .mainFeatureRegisterSeat:
+            let viewModel = MainFeatureViewModel(
+                store: diContainer.resolveAppStore(),
+                coordinator: self,
+                getSeatInSectionUseCase: diContainer.resolveGetSeatInSectionUseCase(),
+                unlockSeatUseCase: diContainer.resolveUnlockSeatUseCase(),
+                registerSeatUseCase: diContainer.resolveRegisterSeatUseCase()
+            )
+            MainFeatureView(viewModel: viewModel)
+        case .mainFeatureMoveSeat:
+            let viewModel = MainFeatureViewModel(
+                store: diContainer.resolveAppStore(),
+                coordinator: self,
+                getSeatInSectionUseCase: diContainer.resolveGetSeatInSectionUseCase(),
+                unlockSeatUseCase: diContainer.resolveUnlockSeatUseCase(),
+                moveSeatUseCase: diContainer.resolveMoveSeatUseCase()
+            )
+            MainFeatureView(viewModel: viewModel)
+        case .mainFeatureCancelSeat:
+            let viewModel = MainFeatureViewModel(
+                store: diContainer.resolveAppStore(),
+                coordinator: self,
+                getSeatInSectionUseCase: diContainer.resolveGetSeatInSectionUseCase(),
+                unlockSeatUseCase: diContainer.resolveUnlockSeatUseCase(),
+                cancelSeatUseCase: diContainer.resolveCancelSeatUseCase()
+            )
+            MainFeatureView(viewModel: viewModel)
+        case .manageSeat:
+            let store = diContainer.resolveAppStore()
+            let viewModel = ManageSeatViewModel(
+                store: store,
+                coordinator: self
+            )
+            ManageSeatView(viewModel: viewModel)
         }
     }
 

--- a/SeatCatcher/SeatCatcher/Sources/App/DIContainer/DIContainerImpl.swift
+++ b/SeatCatcher/SeatCatcher/Sources/App/DIContainer/DIContainerImpl.swift
@@ -24,6 +24,7 @@ final class DIContainerImpl {
     private lazy var userRepository = UserRepositoryImpl(networkService: networkService)
     private lazy var stationsRepository = StationsRepositoryImpl(networkService: networkService)
     private lazy var pathHistoriesRepository = PathHistoriesRepositoryImpl(networkService: networkService)
+    private lazy var seatRepository = SeatRepositoryImpl()
 
     // MARK: - Auth UseCase Instances
     private lazy var appleLoginUseCase = AppleLoginUseCaseImpl(
@@ -52,7 +53,14 @@ final class DIContainerImpl {
 
     // MARK: - Stations UseCase Instances
     private lazy var searchStationsUseCase = SearchStationsUseCaseImpl(stationsRepository: stationsRepository)
-
+    
+    // MARK: - Seat UseCases Instances
+    private lazy var getSeatInSectionUseCase = GetSeatInSectionUseCaseImpl(seatRepository: seatRepository)
+    private lazy var unlockSeatUseCase = UnlockSeatUseCaseImpl(seatRepository: seatRepository)
+    private lazy var registerSeatUseCase: RegisterSeatUseCase = RegisterSeatUseCaseImpl(seatRepository: seatRepository)
+    private lazy var moveSeatUseCase: MoveSeatUseCase = MoveSeatUseCaseImpl(seatRepository: seatRepository)
+    private lazy var cancelSeatUseCase: CancelSeatUseCase = CancelSeatUseCaseImpl(seatRepository: seatRepository)
+    
     // MARK: - PathHistories UseCase Instances
     private lazy var getPathHistoriesUseCase = GetPathHistoriesUseCaseImpl(pathHistoriesRepository: pathHistoriesRepository)
     private lazy var postPathHistoriesUseCase = PostPathHistoriesImpl(pathHistoriesRespotiry: pathHistoriesRepository)
@@ -78,6 +86,13 @@ extension DIContainerImpl: DIContainer {
     // MARK: - PathHistories UseCases
     func resolveGetPathHistoriesUseCase() ->  GetPathHistoriesUseCase { return getPathHistoriesUseCase }
     func resolvePostPathHistoriesUseCase() -> PostPathHistoriesUseCase { return postPathHistoriesUseCase }
+    
+    // MARK: - Seat UseCases
+    func resolveGetSeatInSectionUseCase() -> GetSeatInSectionUseCase { return getSeatInSectionUseCase }
+    func resolveUnlockSeatUseCase() -> UnlockSeatUseCase { return unlockSeatUseCase }
+    func resolveRegisterSeatUseCase() -> RegisterSeatUseCase { return registerSeatUseCase }
+    func resolveMoveSeatUseCase() -> MoveSeatUseCase { return moveSeatUseCase }
+    func resolveCancelSeatUseCase() -> CancelSeatUseCase { return cancelSeatUseCase }
 
     // MARK: - Store
     func resolveAppStore() -> AppStore { return appStore }

--- a/SeatCatcherCore/Sources/SeatCatcherCore/DIContainer/DIContainer.swift
+++ b/SeatCatcherCore/Sources/SeatCatcherCore/DIContainer/DIContainer.swift
@@ -28,6 +28,14 @@ public protocol DIContainer {
     // MARK: - PathHistories UseCases
     func resolveGetPathHistoriesUseCase() -> GetPathHistoriesUseCase
     func resolvePostPathHistoriesUseCase() -> PostPathHistoriesUseCase
+    
+    // MARK: - Seat UseCases
+    func resolveGetSeatInSectionUseCase() -> GetSeatInSectionUseCase
+    func resolveUnlockSeatUseCase() -> UnlockSeatUseCase
+    func resolveRegisterSeatUseCase() -> RegisterSeatUseCase
+    func resolveMoveSeatUseCase() -> MoveSeatUseCase
+    func resolveCancelSeatUseCase() -> CancelSeatUseCase
+
 
     // MARK: - Store
     func resolveAppStore() -> AppStore

--- a/SeatCatcherData/Sources/SeatCatcherData/Repositories/Seat/SeatRepositoryImpl.swift
+++ b/SeatCatcherData/Sources/SeatCatcherData/Repositories/Seat/SeatRepositoryImpl.swift
@@ -27,7 +27,7 @@ public final class SeatRepositoryImpl: SeatRepository, Sendable {
         
         let bottomSeats: [Seat] = [
             Seat(minutesLeft: 12, isAvailable: true, isSeated: false, isBlocked: false, seatDirection: .bottom),
-            Seat(minutesLeft: 7, isAvailable: true, isSeated: true, isBlocked: false, seatDirection: .bottom),
+            Seat(minutesLeft: 7, isAvailable: true, isSeated: false, isBlocked: false, seatDirection: .bottom),
             Seat(minutesLeft: 2, isAvailable: false, isSeated: false, isBlocked: true, seatDirection: .bottom),
             Seat(minutesLeft: 18, isAvailable: true, isSeated: false, isBlocked: false, seatDirection: .bottom),
             Seat(minutesLeft: 9, isAvailable: true, isSeated: false, isBlocked: false, seatDirection: .bottom),

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Common/Components/SeatSectionView.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Common/Components/SeatSectionView.swift
@@ -58,7 +58,7 @@ private struct SeatRowView: View {
                     Image(seat.image(
                         isSelected: selectedSeat?.id == seat.id,
                         isBlocked: isBlocked,
-                        isSelecting: userStatus == .selecting)
+                        isSelecting: userStatus == .registering || userStatus == .moving)
                     )
                     .frame(width: 40, height: 42)
                     .onTapGesture {
@@ -74,7 +74,7 @@ private struct SeatRowView: View {
     
     private func shouldShowSeat(seat: Seat) -> Bool {
         /// 좌석 이동/등록 시엔 점유된 좌석은 보여주지 않습니다
-        if userStatus == .selecting {
+        if userStatus == .registering || userStatus == .moving {
             return seat.isAvailable  // 빈 좌석만 표시
         } else {
             return true  // 다른 상태에서는 모든 좌석 표시

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Common/Components/SeatSectionView.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Common/Components/SeatSectionView.swift
@@ -75,7 +75,7 @@ private struct SeatRowView: View {
     private func shouldShowSeat(seat: Seat) -> Bool {
         /// 좌석 이동/등록 시엔 점유된 좌석은 보여주지 않습니다
         if userStatus == .registering || userStatus == .moving {
-            return seat.isAvailable  // 빈 좌석만 표시
+            return seat.isAvailable || seat.isSeated // 빈 좌석과 앉은 자리만 표시
         } else {
             return true  // 다른 상태에서는 모든 좌석 표시
         }

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Common/SCNavigationBar.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Common/SCNavigationBar.swift
@@ -21,12 +21,14 @@ struct SCNavigationBar: View {
         )
         case title(
             title: String,
-            backButtonAction: (() -> Void)? = nil
+            backButtonAction: (() -> Void)? = nil,
+            applyDefaultPopAction: Bool = true
         )
         case titleWithHomeButton(
             title: String,
             backButtonAction: (() -> Void)? = nil,
-            homeButtonAction: (() -> Void)? = nil
+            homeButtonAction: (() -> Void)? = nil,
+            applyDefaultPopAction: Bool = true
         )
         case stationSelection(
             departureName: String?,
@@ -34,12 +36,14 @@ struct SCNavigationBar: View {
             backButtonAction: (() -> Void)? = nil,
             swapStationsButtonAction: () -> Void,
             selectDepartureButtonAction: () -> Void,
-            selectArrivalButtonAction: () -> Void
+            selectArrivalButtonAction: () -> Void,
+            applyDefaultPopAction: Bool = true
         )
         case search(
             backButtonAction: (() -> Void)? = nil,
             placeholder: String,
-            text: Binding<String>
+            text: Binding<String>,
+            applyDefaultPopAction: Bool = true
         )
     }
     
@@ -52,22 +56,29 @@ struct SCNavigationBar: View {
         VStack(spacing: 0) {
             Group {
                 switch config {
-                case .skip(let skipButtonAction):
+                case let .skip(skipButtonAction):
                     SkipNavigationBar(skipButtonAction: skipButtonAction)
-                case .logoWithNotification(let notificationButtonAction):
+                case let .logoWithNotification(notificationButtonAction):
                     LogoWithNotificationNavigationBar(notificationButtonAction: notificationButtonAction)
-                case let .title(title, backButtonAction):
+                case let .title(title, backButtonAction, applyDefaultPopAction):
                     TitleNavigationBar(
                         title: title,
                         backButtonAction: backButtonAction,
-                        coordinator: coordinator
+                        coordinator: coordinator,
+                        applyDefaultPopAction: applyDefaultPopAction
                     )
-                case let .titleWithHomeButton(title, backButtonAction, homeButtonAction):
+                case let .titleWithHomeButton(
+                    title,
+                    backButtonAction,
+                    homeButtonAction,
+                    applyDefaultPopAction
+                ):
                     TitleWithHomeButtonNavigationBar(
                         title: title,
                         backButtonAction: backButtonAction,
                         homeButtonAction: homeButtonAction,
-                        coordinator: coordinator
+                        coordinator: coordinator,
+                        applyDefaultPopAction: applyDefaultPopAction
                     )
                 case let .stationSelection(
                     departureName,
@@ -75,7 +86,8 @@ struct SCNavigationBar: View {
                     backButtonAction,
                     swapStationsButtonAction,
                     selectDepartureButtonAction,
-                    selectArrivalButtonAction
+                    selectArrivalButtonAction,
+                    applyDefaultPopAction
                 ):
                     StationSelectionNavigationBar(
                         departureName: departureName,
@@ -84,14 +96,21 @@ struct SCNavigationBar: View {
                         swapStationsButtonAction: swapStationsButtonAction,
                         selectDepartureButtonAction: selectDepartureButtonAction,
                         selectArrivalButtonAction: selectArrivalButtonAction,
-                        coordinator: coordinator
+                        coordinator: coordinator,
+                        applyDefaultPopAction: applyDefaultPopAction
                     )
-                case let .search(backButtonAction, placeholder, text):
+                case let .search(
+                    backButtonAction,
+                    placeholder,
+                    text,
+                    applyDefaultPopAction
+                ):
                     SearchNavigationBar(
                         backButtonAction: backButtonAction,
                         placeholder: placeholder,
                         text: text,
-                        coordinator: coordinator
+                        coordinator: coordinator,
+                        applyDefaultPopAction: applyDefaultPopAction
                     )
                 }
             }
@@ -144,13 +163,16 @@ private struct TitleNavigationBar: View {
     let title: String
     let backButtonAction: (() -> Void)?
     let coordinator: Coordinator
+    let applyDefaultPopAction: Bool
 
     var body: some View {
         ZStack(alignment: .center) {
             HStack {
                 Button {
                     backButtonAction?()
-                    coordinator.pop()
+                    if applyDefaultPopAction {
+                        coordinator.pop()
+                    }
                 } label: {
                     Image(.iconLeftArrow)
                         .resizable()
@@ -171,12 +193,15 @@ private struct TitleWithHomeButtonNavigationBar: View {
     let backButtonAction: (() -> Void)?
     let homeButtonAction: (() -> Void)?
     let coordinator: Coordinator
+    let applyDefaultPopAction: Bool
 
     var body: some View {
         HStack {
             Button {
                 backButtonAction?()
-                coordinator.pop()
+                if applyDefaultPopAction {
+                    coordinator.pop()
+                }
             } label: {
                 Image(.iconLeftArrow)
                     .resizable()
@@ -189,7 +214,9 @@ private struct TitleWithHomeButtonNavigationBar: View {
             Spacer()
             Button(action: {
                 homeButtonAction?()
-                coordinator.popToRoot()
+                if applyDefaultPopAction {
+                    coordinator.popToRoot()
+                }
             }) {
                 Image(.iconHome)
                     .resizable()
@@ -208,12 +235,15 @@ private struct StationSelectionNavigationBar: View {
     let selectDepartureButtonAction: () -> Void
     let selectArrivalButtonAction: () -> Void
     let coordinator: Coordinator
+    let applyDefaultPopAction: Bool
 
     var body: some View {
         HStack(alignment: .top, spacing: 8) {
             Button {
                 backButtonAction?()
-                coordinator.pop()
+                if applyDefaultPopAction {
+                    coordinator.pop()
+                }
             } label: {
                 Image(.iconLeftArrow)
                     .resizable()
@@ -265,12 +295,15 @@ private struct SearchNavigationBar: View {
     let placeholder: String
     let text: Binding<String>
     let coordinator: Coordinator
+    let applyDefaultPopAction: Bool
 
     var body: some View {
         HStack(alignment: .top, spacing: 8) {
             Button {
                 backButtonAction?()
-                coordinator.pop()
+                if applyDefaultPopAction {
+                    coordinator.pop()
+                }
             } label: {
                 Image(.iconLeftArrow)
                     .resizable()

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureLiterals.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureLiterals.swift
@@ -31,7 +31,7 @@ public enum MainFeatureLiterals {
             return (title: seatSection.rawValue + "에서\n앉아 있어요", subtitle: nil)
         case .standing:
             return (title: seatSection.rawValue + "에서\n원하는 좌석을 찾아보세요", subtitle: "빨리 비워지는 좌석일수록 밝아져요")
-        case .selecting:
+        case .registering, .moving:
             return (title: seatSection.rawValue + "에서\n내가 앉은 좌석을 선택해주세요", subtitle: "허위 등록 시, 이용이 제한될 수 있습니다.")
         case .cancelling:
             return (title: "현재 좌석등록을\n정말 취소하시겠어요?", subtitle: "등록 후, 5분 내 취소 시 리워드는 회수됩니다.")

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureView.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureView.swift
@@ -46,7 +46,7 @@ public struct MainFeatureView: View {
                 .padding(.bottom, 20)
             }
             CTAButtonView(viewModel: viewModel)
-            .padding(.bottom, 2)
+                .padding(.bottom, 2)
         }
         .padding(.horizontal, 18)
         .frame(maxWidth: .infinity)
@@ -153,9 +153,16 @@ private struct CTAButtonView: View {
     let viewModel: MainFeatureViewModel
     
     var body: some View {
-        let ctaButtonTitle = switch viewModel.state.userStatus {
+        let ctaButtonTitle: String = switch viewModel.state.userStatus {
         case .seated, .standing: MainFeatureLiterals.BottomButton.manageSeat.rawValue
         case .registering, .moving, .cancelling: MainFeatureLiterals.BottomButton.confirm.rawValue
+        }
+        let ctaButtonStyle: CTAButton.SCButtonStyle = switch viewModel.state.userStatus {
+        case .registering, .moving:
+            viewModel.state.seatSectionState.selectedSeat != nil
+            ? .bottomEnabled
+            : .bottomDisabled
+        case .seated, .standing, .cancelling: .bottomEnabled
         }
         CTAButton(
             title: ctaButtonTitle,
@@ -175,7 +182,7 @@ private struct CTAButtonView: View {
                     viewModel.action(.willCancelSeat)
                 }
             },
-            style: .bottomMain
+            style: ctaButtonStyle
         )
     }
 }

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureView.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureView.swift
@@ -18,7 +18,7 @@ public struct MainFeatureView: View {
     
     public var body: some View {
         VStack(spacing: 0) {
-            TitleTextView(seatSection: viewModel.state.seatSection, status: .standing)
+            TitleTextView(seatSection: viewModel.state.seatSection, status: viewModel.state.userStatus)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.top, 18)
                 .padding(.bottom, 32)
@@ -32,7 +32,9 @@ public struct MainFeatureView: View {
                 }
             )
             .padding(.bottom, 12)
-            LookingCountView(count: viewModel.state.lookingCount)
+            if viewModel.state.lookingCount > 0 {
+                LookingCountView(count: viewModel.state.lookingCount)
+            }
             Spacer()
             if let section = viewModel.state.nearestAvailableSection {
                 ToastAlertView(
@@ -43,13 +45,7 @@ public struct MainFeatureView: View {
                 )
                 .padding(.bottom, 20)
             }
-            CTAButton(
-                title: MainFeatureLiterals.BottomButton.manageSeat.rawValue,
-                action: {
-                    viewModel.action(.manageMySeatButtonDidTap)
-                },
-                style: .bottomMain
-            )
+            CTAButtonView(viewModel: viewModel)
             .padding(.bottom, 2)
         }
         .padding(.horizontal, 18)
@@ -87,6 +83,7 @@ private struct TitleTextView: View {
                 Text(subtitle)
                     .font(.B03_M)
                     .foregroundStyle(.gray300)
+                    .underline(status != .standing)
             } else {
                 Spacer()
                     .frame(height: 18)
@@ -148,5 +145,37 @@ private struct ToastAlertView: View {
         .frame(height: 40)
         .background(.gray500)
         .clipShape(Capsule())
+    }
+}
+
+private struct CTAButtonView: View {
+    
+    let viewModel: MainFeatureViewModel
+    
+    var body: some View {
+        let ctaButtonTitle = switch viewModel.state.userStatus {
+        case .seated, .standing: MainFeatureLiterals.BottomButton.manageSeat.rawValue
+        case .registering, .moving, .cancelling: MainFeatureLiterals.BottomButton.confirm.rawValue
+        }
+        CTAButton(
+            title: ctaButtonTitle,
+            action: {
+                switch viewModel.state.userStatus {
+                case .seated, .standing:
+                    viewModel.action(.manageMySeatButtonDidTap)
+                case .registering:
+                    if let seat = viewModel.state.seatSectionState.selectedSeat {
+                        viewModel.action(.willRegisterSeat(seat))
+                    }
+                case .moving:
+                    if let seat = viewModel.state.seatSectionState.selectedSeat {
+                        viewModel.action(.willMoveSeat(seat))
+                    }
+                case .cancelling:
+                    viewModel.action(.willCancelSeat)
+                }
+            },
+            style: .bottomMain
+        )
     }
 }

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureView.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureView.swift
@@ -60,7 +60,8 @@ public struct MainFeatureView: View {
             config: .titleWithHomeButton(
                 title: "좌석찾기",
                 backButtonAction: { viewModel.action(.backButtonDidTap) },
-                homeButtonAction: { viewModel.action(.homeButtonDidTap) }
+                homeButtonAction: { viewModel.action(.homeButtonDidTap) },
+                applyDefaultPopAction: false
             )
         )
         .onAppear {

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureViewModel.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureViewModel.swift
@@ -217,6 +217,15 @@ public final class MainFeatureViewModel: ViewModel {
         Task {
             do {
                 state.seatSectionState.seats = try await getSeatInSectionUseCase.execute()
+                if self.state.userStatus == .registering || self.state.userStatus == .moving {
+                    self.state.seatSectionState.selectedSeat
+                    = state.seatSectionState.seats.topSeats.first(
+                        where: { $0.isSeated }
+                    )
+                    ?? state.seatSectionState.seats.bottomSeats.first(
+                        where: { $0.isSeated }
+                    )
+                }
             } catch {
                 print(error.localizedDescription)
             }

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureViewModel.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureViewModel.swift
@@ -47,7 +47,7 @@ public final class MainFeatureViewModel: ViewModel {
     }
     
     // MARK: Dependencies
-    let appStore: AppStore
+    let store: AppStore
     let coordinator: Coordinator
     
     // MARK: States
@@ -64,11 +64,9 @@ public final class MainFeatureViewModel: ViewModel {
     
     
     // MARK: Initialize
-    init(
-        appStore: AppStore,
+    public init(
+        store: AppStore,
         coordinator: Coordinator,
-        isBlocked: Bool,
-        seatSection: SeatSection,
         getSeatInSectionUseCase: GetSeatInSectionUseCase,
         unlockSeatUseCase: UnlockSeatUseCase,
         registerSeatUseCase: RegisterSeatUseCase? = nil,
@@ -76,7 +74,7 @@ public final class MainFeatureViewModel: ViewModel {
         cancelSeatUseCase: CancelSeatUseCase? = nil,
         userStatus: UserStatus
     ) {
-        self.appStore = appStore
+        self.store = store
         self.coordinator = coordinator
         self.getSeatInSectionUseCase = getSeatInSectionUseCase
         self.unlockSeatUseCase = unlockSeatUseCase
@@ -86,75 +84,80 @@ public final class MainFeatureViewModel: ViewModel {
         self.state = .init(
             nearestAvailableSection: nil, // 초깃값
             userStatus: userStatus,
-            seatSection: seatSection,
+            seatSection: .normal_A, // FIXME: 전역 관리 필요
             lookingCount: 0, // 초깃값
             seatSectionState: .init(
                 selectedSeat: nil,
-                isBlocked: isBlocked,
+                isBlocked: false, // FIXME: 전역 관리 필요
                 seats: (topSeats: [], bottomSeats: [])
             )
         )
     }
     
+    
+    // MARK: 기본
+    public convenience init(
+        store: AppStore,
+        coordinator: Coordinator,
+        getSeatInSectionUseCase: GetSeatInSectionUseCase,
+        unlockSeatUseCase: UnlockSeatUseCase
+    ) {
+        self.init(
+            store: store,
+            coordinator: coordinator,
+            getSeatInSectionUseCase: getSeatInSectionUseCase,
+            unlockSeatUseCase: unlockSeatUseCase,
+            userStatus: .standing
+        )
+    }
+    
     // MARK: 좌석 등록하는 경우
     public convenience init(
-        appStore: AppStore,
+        store: AppStore,
         coordinator: Coordinator,
-        isBlocked: Bool,
-        seatSection: SeatSection,
         getSeatInSectionUseCase: GetSeatInSectionUseCase,
         unlockSeatUseCase: UnlockSeatUseCase,
         registerSeatUseCase: RegisterSeatUseCase
     ) {
         self.init(
-            appStore: appStore,
+            store: store,
             coordinator: coordinator,
-            isBlocked: isBlocked,
-            seatSection: seatSection,
             getSeatInSectionUseCase: getSeatInSectionUseCase,
             unlockSeatUseCase: unlockSeatUseCase,
             registerSeatUseCase: registerSeatUseCase,
-            userStatus: .selecting
+            userStatus: .registering
         )
     }
     
     // MARK: 좌석 이동하는 경우
     public convenience init(
-        appStore: AppStore,
+        store: AppStore,
         coordinator: Coordinator,
-        isBlocked: Bool,
-        seatSection: SeatSection,
         getSeatInSectionUseCase: GetSeatInSectionUseCase,
         unlockSeatUseCase: UnlockSeatUseCase,
         moveSeatUseCase: MoveSeatUseCase
     ) {
         self.init(
-            appStore: appStore,
+            store: store,
             coordinator: coordinator,
-            isBlocked: isBlocked,
-            seatSection: seatSection,
             getSeatInSectionUseCase: getSeatInSectionUseCase,
             unlockSeatUseCase: unlockSeatUseCase,
             moveSeatUseCase: moveSeatUseCase,
-            userStatus: .selecting
+            userStatus: .moving
         )
     }
     
     // MARK: 좌석 취소하는 경우
     public convenience init(
-        appStore: AppStore,
+        store: AppStore,
         coordinator: Coordinator,
-        isBlocked: Bool,
-        seatSection: SeatSection,
         getSeatInSectionUseCase: GetSeatInSectionUseCase,
         unlockSeatUseCase: UnlockSeatUseCase,
         cancelSeatUseCase: CancelSeatUseCase
     ) {
         self.init(
-            appStore: appStore,
+            store: store,
             coordinator: coordinator,
-            isBlocked: isBlocked,
-            seatSection: seatSection,
             getSeatInSectionUseCase: getSeatInSectionUseCase,
             unlockSeatUseCase: unlockSeatUseCase,
             cancelSeatUseCase: cancelSeatUseCase,
@@ -174,8 +177,7 @@ public final class MainFeatureViewModel: ViewModel {
         case .homeButtonDidTap:
             coordinator.popToRoot()
         case .manageMySeatButtonDidTap:
-            //TODO: 좌석 관리 페이지로 이동
-            break
+            coordinator.push(AppScene.manageSeat)
         case .willRegisterSeat:
             registerSeat()
         case .willMoveSeat:
@@ -263,7 +265,8 @@ public final class MainFeatureViewModel: ViewModel {
     public enum UserStatus {
         case seated // 착석 중
         case standing // 자리 찾는 중
-        case selecting // 좌석 관리 - 앉은 자리 등록 or 이동 중
+        case registering // 좌석 관리 - 앉은 자리 등록 중
+        case moving // 좌석 관리 - 앉은 자리 이동 중
         case cancelling // 좌석 관리 - 앉은 자리 취소 중
     }
 }

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/ManageSeat/ManageSeatView.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/ManageSeat/ManageSeatView.swift
@@ -1,0 +1,90 @@
+//
+//  ManageSeatView.swift
+//  SeatCatcherPresentation
+//
+//  Created by 황채웅 on 5/25/25.
+//
+
+import SwiftUI
+
+public struct ManageSeatView: View {
+    
+    @State private var viewModel: ManageSeatViewModel
+    
+    public init(viewModel: ManageSeatViewModel) {
+        self._viewModel = State(initialValue: viewModel)
+    }
+    
+    public var body: some View {
+        VStack(spacing: 0) {
+            Text("현재 상황에 맞게\n착석 정보를 관리해 주세요")
+                .font(.T02_B)
+                .foregroundStyle(.gray100)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.top, 18)
+                .padding(.bottom, 20)
+            VStack(spacing: 10) {
+                ForEach(ManageSeatViewModel.ManageSeatOption.allCases, id: \.self) { option in
+                    ManageSeatOptionView(viewModel: viewModel, option: option)
+                }
+            }
+            Spacer()
+            CTAButton(
+                title: "다음",
+                action: { viewModel.action(.didSelectOption) },
+                style:
+                    viewModel.state.selectedOption != nil ? .bottomEnabled : .bottomDisabled
+            )
+            .padding(.bottom, 2)
+        }
+        .padding(.horizontal, 18)
+        .frame(maxWidth: .infinity)
+        .withBackground(.gray900)
+        .withNavigationBar(
+            viewModel.coordinator,
+            config: .titleWithHomeButton(
+                title: "좌석 찾기",
+                backButtonAction: { viewModel.action(.backButtonDidTap) },
+                homeButtonAction: { viewModel.action(.homeButtonDidTap) },
+                applyDefaultPopAction: false
+            )
+        )
+    }
+}
+
+private struct ManageSeatOptionView: View {
+    
+    let viewModel: ManageSeatViewModel
+    let option: ManageSeatViewModel.ManageSeatOption
+    
+    var body: some View {
+        HStack(spacing: 2) {
+            Image(option.icon)
+                .resizable()
+                .renderingMode(.template)
+                .frame(width: 24, height: 24)
+                .foregroundStyle(
+                    viewModel.state.selectedOption == option
+                    ? .scGreen
+                    : .gray300
+                )
+            Text(option.rawValue)
+                .font(.B02_SB)
+                .foregroundStyle(
+                    viewModel.state.selectedOption == option
+                    ? .scGreen
+                    : .gray300
+                )
+        }
+        .withBackground(
+            viewModel.state.selectedOption == option
+            ? .scGreen700
+            : .gray500
+        )
+        .frame(height: 60)
+        .clipShape(.rect(cornerRadius: 10))
+        .onTapGesture {
+            viewModel.action(.willSelectOption(option))
+        }
+    }
+}

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/ManageSeat/ManageSeatViewModel.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/ManageSeat/ManageSeatViewModel.swift
@@ -40,14 +40,15 @@ public class ManageSeatViewModel: ViewModel {
     }
     
     // MARK: Dependencies
-    let appStore: AppStore
+    let store: AppStore
     let coordinator: Coordinator
     private(set) var state = State(selectedOption: nil)
     
-    public init(appStore: AppStore,
-         coordinator: Coordinator
+    public init(
+        store: AppStore,
+        coordinator: Coordinator
     ) {
-        self.appStore = appStore
+        self.store = store
         self.coordinator = coordinator
     }
     
@@ -60,8 +61,17 @@ public class ManageSeatViewModel: ViewModel {
                 state.selectedOption = option // 변경
             }
         case .didSelectOption:
-            // TODO: 코디네이터 push
-            break
+            if let option = state.selectedOption {
+                let scene = switch option {
+                case .register:
+                    AppScene.mainFeatureRegisterSeat
+                case .move:
+                    AppScene.mainFeatureMoveSeat
+                case .cancel:
+                    AppScene.mainFeatureCancelSeat
+                }
+                coordinator.push(scene)
+            }
         case .backButtonDidTap:
             coordinator.pop()
         case .homeButtonDidTap:

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/ManageSeat/ManageSeatViewModel.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/ManageSeat/ManageSeatViewModel.swift
@@ -1,0 +1,71 @@
+//
+//  ManageSeatViewModel.swift
+//  SeatCatcherPresentation
+//
+//  Created by 황채웅 on 5/25/25.
+//
+
+import Foundation
+import SwiftUI
+import SeatCatcherCore
+
+@Observable
+public class ManageSeatViewModel: ViewModel {
+    enum Action {
+        case willSelectOption(ManageSeatOption)
+        case didSelectOption
+        case backButtonDidTap
+        case homeButtonDidTap
+    }
+    
+    enum ManageSeatOption: String, CaseIterable {
+        case register = "앉은좌석 등록하기"
+        case move = "앉은좌석 이동하기"
+        case cancel = "앉은좌석 취소하기"
+        
+        var icon: ImageResource {
+            switch self {
+            case .register:
+                return .iconRegister
+            case .move:
+                return .iconMove
+            case .cancel:
+                return .iconCancel
+            }
+        }
+    }
+    
+    struct State {
+        var selectedOption: ManageSeatOption?
+    }
+    
+    // MARK: Dependencies
+    let appStore: AppStore
+    let coordinator: Coordinator
+    private(set) var state = State(selectedOption: nil)
+    
+    public init(appStore: AppStore,
+         coordinator: Coordinator
+    ) {
+        self.appStore = appStore
+        self.coordinator = coordinator
+    }
+    
+    func action(_ action: Action) {
+        switch action {
+        case .willSelectOption(let option):
+            if option == state.selectedOption {
+                state.selectedOption = nil // 재탭
+            } else {
+                state.selectedOption = option // 변경
+            }
+        case .didSelectOption:
+            // TODO: 코디네이터 push
+            break
+        case .backButtonDidTap:
+            coordinator.pop()
+        case .homeButtonDidTap:
+            coordinator.popToRoot()
+        }
+    }
+}

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Helper/Seat+.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Helper/Seat+.swift
@@ -18,10 +18,22 @@ extension Seat {
         if isBlocked {
             return ImageResource(name: "\(directionPrefix)_blocked", bundle: .module)
         }
-        // 내가 앉은 자리 or 앉을 자리 선택 시
-        if isSeated || (isSelecting && isSelected) {
+        
+        // 등록/이동 중 선택한 자리인 경우
+        // 등록/이동 중 아닐 때 내가 앉은 자리인 경우
+        if isSelecting {
+            if isSelected {
+                return ImageResource(name: "\(directionPrefix)_user", bundle: .module)
+            } else {
+                return ImageResource(name: "\(directionPrefix)_empty", bundle: .module)
+            }
+        }
+        
+        // 내가 앉아있는 자리
+        if isSeated {
             return ImageResource(name: "\(directionPrefix)_user", bundle: .module)
         }
+        
         // 빈 자리
         if isAvailable {
             return ImageResource(name: "\(directionPrefix)_empty", bundle: .module)

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Resources/Assets.xcassets/Icons/icon_cancel.imageset/Contents.json
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Resources/Assets.xcassets/Icons/icon_cancel.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "icon_cancel.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Resources/Assets.xcassets/Icons/icon_cancel.imageset/icon_cancel.svg
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Resources/Assets.xcassets/Icons/icon_cancel.imageset/icon_cancel.svg
@@ -1,0 +1,5 @@
+<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M15.1052 9.39062L9.88672 14.6091" stroke="#9297A1" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9.88672 9.39062L15.1052 14.6091" stroke="#9297A1" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12.5 20C16.9183 20 20.5 16.4183 20.5 12C20.5 7.58172 16.9183 4 12.5 4C8.08172 4 4.5 7.58172 4.5 12C4.5 16.4183 8.08172 20 12.5 20Z" stroke="#9297A1" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Resources/Assets.xcassets/Icons/icon_move.imageset/Contents.json
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Resources/Assets.xcassets/Icons/icon_move.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "icon_move.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Resources/Assets.xcassets/Icons/icon_move.imageset/icon_move.svg
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Resources/Assets.xcassets/Icons/icon_move.imageset/icon_move.svg
@@ -1,0 +1,5 @@
+<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11.2701 16.3077L8.80859 13.8462H16.1932" stroke="#9297A1" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M13.7317 7.69238L16.1932 10.1539H8.80859" stroke="#9297A1" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12.5 20C16.9183 20 20.5 16.4183 20.5 12C20.5 7.58172 16.9183 4 12.5 4C8.08172 4 4.5 7.58172 4.5 12C4.5 16.4183 8.08172 20 12.5 20Z" stroke="#9297A1" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Resources/Assets.xcassets/Icons/icon_register.imageset/Contents.json
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Resources/Assets.xcassets/Icons/icon_register.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "icon_register.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Resources/Assets.xcassets/Icons/icon_register.imageset/icon_register.svg
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Resources/Assets.xcassets/Icons/icon_register.imageset/icon_register.svg
@@ -1,0 +1,5 @@
+<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12.5 20C16.9183 20 20.5 16.4183 20.5 12C20.5 7.58172 16.9183 4 12.5 4C8.08172 4 4.5 7.58172 4.5 12C4.5 16.4183 8.08172 20 12.5 20Z" stroke="#9297A1" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12.5 8.30762V15.6922" stroke="#9297A1" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8.80859 12H16.1932" stroke="#9297A1" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Route/AppRoute.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Route/AppRoute.swift
@@ -14,6 +14,11 @@ public enum AppScene: AppRoute {
     case selectLine
     case selectPath(line: Int)
     case searchStations(viewModel: SelectPathViewModel)
+    case mainFeature(hasSeated: Bool)
+    case mainFeatureRegisterSeat
+    case mainFeatureMoveSeat
+    case mainFeatureCancelSeat
+    case manageSeat
 
     public var id: String {
         switch self {
@@ -22,6 +27,11 @@ public enum AppScene: AppRoute {
         case .selectLine: return "selectLine"
         case .selectPath: return "selectPath"
         case .searchStations: return "searchStations"
+        case .mainFeature: return "mainFeature"
+        case .mainFeatureRegisterSeat: return "mainFeatureRegisterSeat"
+        case .mainFeatureMoveSeat: return "mainFeatureMoveSeat"
+        case .mainFeatureCancelSeat: return "mainFeatureCancelSeat"
+        case .manageSeat: return "manageSeat"
         }
     }
 


### PR DESCRIPTION
## ✅ Description
- 좌석 관리 옵션에 따라 분기처리한 메인피쳐 뷰를 `AppScene`/`AppCoordinator`로 플로우를 연결하였습니다
  - `MainFeatureLiterals`를 사용하여 제목/부제목/CTA버튼 문구 분기처리를 하였습니다
- 좌석 관리 옵션 선택 상태를 구현하였습니다
  - 같은 옵션 재선택 시 선택상태 풀리고 CTA 버튼 비활성화
- 메인피쳐 분기처리
  - 좌석 등록
    - 데이터가 있는 좌석은 숨김처리
    - 좌석 선택 시 앉은 자리 이미지로 변경
    - 초기 선택 상태 : 앉아있던 좌석 (앉아있을 때 등록으로 들어가도 문제없이 작동)
    - 같은 좌석 재선택 시 선택상태 풀리고 CTA 버튼 비활성화
  - 좌석 이동
    - 데이터가 있는 좌석은 숨김처리
    - 좌석 선택 시 앉은 자리 이미지로 변경
    - 초기 선택 상태 : 앉아있던 좌석
    - 같은 좌석 재선택 시 선택상태 풀리고 CTA 버튼 비활성화
  - 좌석 취소
    - 좌석 선택 불가능, 터치 무시

## ⭐️ PR Point
<!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
- 작업 논의 필요한 부분
  - 웹소켓 구독 상태 관리
    - 차량 번호
    - 열차 번호
  - 메인피쳐 상태 관리
    - 탑승 중 여부
    - 좌석 잠금 해제 여부
    - 구역 정보

## 📸 Simulator

https://github.com/user-attachments/assets/05819dfd-bb46-45c6-b6b8-d1c69b2e18e2

## 💡 Issue
- Resolved: #39 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 좌석 관리 기능(등록, 이동, 취소)과 관련된 새로운 화면 및 플로우가 추가되었습니다.
  - 좌석 관리 옵션(등록/이동/취소) 선택이 가능한 화면이 도입되었습니다.
  - 각 좌석 관리 옵션에 맞는 아이콘이 추가되었습니다.

- **개선사항**
  - 메인 기능 화면에서 사용자의 상태에 따라 버튼 문구, 스타일, 동작이 동적으로 변경됩니다.
  - 좌석 선택 및 표시 로직이 사용자 상태(등록/이동)에 맞게 개선되었습니다.
  - 네비게이션 바의 뒤로가기/홈 버튼 동작을 옵션에 따라 제어할 수 있습니다.

- **버그 수정**
  - 좌석 표시 및 선택 관련 조건이 보다 명확하게 동작하도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->