### PR TITLE
[#47] 메인피쳐 뷰 좌석 업데이트 STOMP 엔드포인트 연동

### DIFF
--- a/SeatCatcher/SeatCatcher/Sources/App/Coordinator/AppCoordinator.swift
+++ b/SeatCatcher/SeatCatcher/Sources/App/Coordinator/AppCoordinator.swift
@@ -103,7 +103,8 @@ final class AppCoordinator: Coordinator {
                 coordinator: self,
                 getSeatInTrainCarUseCase: diContainer.resolveGetSeatInTrainCarUseCase(),
                 getSeatInSectionUseCase: diContainer.resolveGetSeatInSectionUseCase(),
-                unlockSeatUseCase: diContainer.resolveUnlockSeatUseCase()
+                unlockSeatUseCase: diContainer.resolveUnlockSeatUseCase(),
+                subscribeTrainUseCase: diContainer.resolveSubscribeTrainUseCase()
             )
             MainFeatureView(viewModel: viewModel)
         case .mainFeatureRegisterSeat:

--- a/SeatCatcher/SeatCatcher/Sources/App/DIContainer/DIContainerImpl.swift
+++ b/SeatCatcher/SeatCatcher/Sources/App/DIContainer/DIContainerImpl.swift
@@ -27,6 +27,7 @@ final class DIContainerImpl {
     private lazy var pathHistoriesRepository = PathHistoriesRepositoryImpl(networkService: networkService)
     private lazy var seatRepository = SeatRepositoryImpl(networkService: networkService)
     private lazy var incomingsRepository = IncomingsRepositoryImpl(networkService: networkService)
+    private lazy var seatStompRepository = SeatStompRepositoryImpl(stompClientService: stompClientService)
 
     // MARK: - Auth UseCase Instances
     private lazy var appleLoginUseCase = AppleLoginUseCaseImpl(
@@ -63,6 +64,7 @@ final class DIContainerImpl {
     private lazy var registerSeatUseCase: RegisterSeatUseCase = RegisterSeatUseCaseImpl(seatRepository: seatRepository)
     private lazy var moveSeatUseCase: MoveSeatUseCase = MoveSeatUseCaseImpl(seatRepository: seatRepository)
     private lazy var cancelSeatUseCase: CancelSeatUseCase = CancelSeatUseCaseImpl(seatRepository: seatRepository)
+    private lazy var subscribeTrainUseCase: SubscribeTrainUseCase = SubscribeTrainUseCaseImpl(seatStompRepository: seatStompRepository)
     
     // MARK: - PathHistories UseCase Instances
     private lazy var getPathHistoriesUseCase = GetPathHistoriesUseCaseImpl(pathHistoriesRepository: pathHistoriesRepository)
@@ -102,6 +104,7 @@ extension DIContainerImpl: DIContainer {
     func resolveRegisterSeatUseCase() -> RegisterSeatUseCase { return registerSeatUseCase }
     func resolveMoveSeatUseCase() -> MoveSeatUseCase { return moveSeatUseCase }
     func resolveCancelSeatUseCase() -> CancelSeatUseCase { return cancelSeatUseCase }
+    func resolveSubscribeTrainUseCase() -> SubscribeTrainUseCase { return subscribeTrainUseCase }
 
     // MARK: Incomings UseCases
     func resolveGetIncomingsUseCase() -> GetIncomingsUseCase { return getIncomingsUseCase }

--- a/SeatCatcherCore/Sources/SeatCatcherCore/DIContainer/DIContainer.swift
+++ b/SeatCatcherCore/Sources/SeatCatcherCore/DIContainer/DIContainer.swift
@@ -37,6 +37,7 @@ public protocol DIContainer {
     func resolveRegisterSeatUseCase() -> RegisterSeatUseCase
     func resolveMoveSeatUseCase() -> MoveSeatUseCase
     func resolveCancelSeatUseCase() -> CancelSeatUseCase
+    func resolveSubscribeTrainUseCase() -> SubscribeTrainUseCase
 
     // MARK: - Incoming UseCases
     func resolveGetIncomingsUseCase() -> GetIncomingsUseCase

--- a/SeatCatcherData/Sources/SeatCatcherData/DTOs/SeatCatcherDataError/SeatCatcherDataError.swift
+++ b/SeatCatcherData/Sources/SeatCatcherData/DTOs/SeatCatcherDataError/SeatCatcherDataError.swift
@@ -11,12 +11,14 @@ enum SeatCatcherDataError: Error {
     case InvalidSeatSectionType // 구역 파싱 오류
     case FailedToGetRowCount // 좌석 개수 파싱 오류
     case InvalidSeatType // 좌석 타입 파싱 오류
+    case nullValue // 빈 데이터 수신 오류
     
     var description: String {
         switch self {
         case .InvalidSeatSectionType: "구역 파싱 오류"
         case .FailedToGetRowCount: "좌석 개수 파싱 오류"
         case .InvalidSeatType: "좌석 타입 파싱 오류"
+        case .nullValue: "빈 데이터 수신 오류"
         }
     }
 }

--- a/SeatCatcherData/Sources/SeatCatcherData/DTOs/Trains/GetSeatInTrainCarResponseDTO.swift
+++ b/SeatCatcherData/Sources/SeatCatcherData/DTOs/Trains/GetSeatInTrainCarResponseDTO.swift
@@ -179,7 +179,6 @@ extension GetSeatInTrainCarResponseDTO: ResponseDTO {
         
         return Seat(
             id: seat.seatId,
-            isSeated: seat.occupant?.userId == 0, // FIXME: 유저 데이터와 비교
             seatType: seatType,
             seatDirection: isTopSeat ? .top : .bottom,
             occupant: occupant

--- a/SeatCatcherData/Sources/SeatCatcherData/DTOs/User/GetUserResponseDTO.swift
+++ b/SeatCatcherData/Sources/SeatCatcherData/DTOs/User/GetUserResponseDTO.swift
@@ -8,6 +8,7 @@
 import SeatCatcherDomain
 
 struct GetUserResponseDTO {
+    let userId: Int
     let name: String
     let profileImageNum: String
     let tags: [String]
@@ -18,10 +19,11 @@ struct GetUserResponseDTO {
 extension GetUserResponseDTO: ResponseDTO {
     typealias DomainModel = User
 
-    static var stub: Self { .init(name: "Stub", profileImageNum: "Image_1", tags: ["USERTAG_NULL"], credit: 0, hasOnBoarded: true) }
+    static var stub: Self { .init(userId: 0, name: "Stub", profileImageNum: "Image_1", tags: ["USERTAG_NULL"], credit: 0, hasOnBoarded: true) }
 
     var domainModel: User {
         User(
+            id: userId,
             name: name,
             profileImage: UserImage(rawValue: profileImageNum) ?? .catchy1,
             tags: tags.compactMap { UserTag(rawValue: $0) },

--- a/SeatCatcherData/Sources/SeatCatcherData/DTOs/User/PatchUserResponseDTO.swift
+++ b/SeatCatcherData/Sources/SeatCatcherData/DTOs/User/PatchUserResponseDTO.swift
@@ -8,6 +8,7 @@
 import SeatCatcherDomain
 
 struct PatchUserResponseDTO {
+    let userId: Int
     let name: String
     let profileImageNum: String
     let tags: [String]
@@ -18,10 +19,11 @@ struct PatchUserResponseDTO {
 extension PatchUserResponseDTO: ResponseDTO {
     typealias DomainModel = User
 
-    static var stub: Self { .init(name: "Stub", profileImageNum: "Image_1", tags: ["USERTAG_NULL"], credit: 0, hasOnBoarded: true) }
+    static var stub: Self { .init(userId: 0, name: "Stub", profileImageNum: "Image_1", tags: ["USERTAG_NULL"], credit: 0, hasOnBoarded: true) }
 
     var domainModel: User {
         User(
+            id: userId,
             name: name,
             profileImage: UserImage(rawValue: profileImageNum) ?? .catchy1,
             tags: tags.compactMap { UserTag(rawValue: $0) },

--- a/SeatCatcherData/Sources/SeatCatcherData/Repositories/Seat/SeatStompRepositoryImpl.swift
+++ b/SeatCatcherData/Sources/SeatCatcherData/Repositories/Seat/SeatStompRepositoryImpl.swift
@@ -11,24 +11,29 @@ import SeatCatcherDomain
 import SeatCatcherData
 
 /// STOMP를 통해 좌석 데이터를 처리하는 리포지토리 구현체
-final class SeatStompRepositoryImpl: SeatStompRepository {
-    private let stompClient: StompClientServiceProtocol
+public final class SeatStompRepositoryImpl: SeatStompRepository {
+    private let stompClientService: StompClientService
     private let decoder = JSONDecoder()
     private let messageSubject = PassthroughSubject<TrainCar, Error>()
     private var cancellables = Set<AnyCancellable>()
     
-    /// 유즈케이스에서 구독할 퍼블리셔입니다
-    var trainCarPublisher: AnyPublisher<TrainCar, Error> {
-        messageSubject.eraseToAnyPublisher()
+    public var isConnectedPublisher: AnyPublisher<Bool, Never> {
+        stompClientService.isConnectedPublisher
     }
     
-    public init(stompClient: StompClientServiceProtocol) {
-        self.stompClient = stompClient
+    public init(stompClientService: StompClientService) {
+        self.stompClientService = stompClientService
         bindStompMessages()
     }
     
+    public func trainCarPublisher(carCode: String) -> AnyPublisher<TrainCar, Error> {
+        messageSubject
+            .filter { $0.carCode == carCode }
+            .eraseToAnyPublisher()
+    }
+    
     private func bindStompMessages() {
-        stompClient.messagePublisher
+        stompClientService.messagePublisher
             .receive(on: DispatchQueue.main)
             .sink(receiveCompletion: { [weak self] completion in
                 if case let .failure(error) = completion {
@@ -55,13 +60,13 @@ final class SeatStompRepositoryImpl: SeatStompRepository {
         }
     }
     
-    func subscribeToTrainCarSeats(trainCode: String) {
+    public func subscribeToTrainCarSeats(trainCode: String) {
         let topic = "/train/\(trainCode)"
-        stompClient.subscribe(topic: topic)
+        stompClientService.subscribe(topic: topic)
     }
     
-    func unsubscribeFromTrainCarSeats(trainCode: String) {
+    public func unsubscribeFromTrainCarSeats(trainCode: String) {
         let topic = "/train/\(trainCode)"
-        stompClient.unsubscribe(topic: topic)
+        stompClientService.unsubscribe(topic: topic)
     }
 }

--- a/SeatCatcherData/Sources/SeatCatcherData/Repositories/Seat/SeatStompRepositoryImpl.swift
+++ b/SeatCatcherData/Sources/SeatCatcherData/Repositories/Seat/SeatStompRepositoryImpl.swift
@@ -1,0 +1,67 @@
+//
+//  SeatStompRepositoryImpl.swift
+//  SeatCatcherData
+//
+//  Created by 황채웅 on 6/3/25.
+//
+
+import Foundation
+import Combine
+import SeatCatcherDomain
+import SeatCatcherData
+
+/// STOMP를 통해 좌석 데이터를 처리하는 리포지토리 구현체
+final class SeatStompRepositoryImpl: SeatStompRepository {
+    private let stompClient: StompClientServiceProtocol
+    private let decoder = JSONDecoder()
+    private let messageSubject = PassthroughSubject<TrainCar, Error>()
+    private var cancellables = Set<AnyCancellable>()
+    
+    /// 유즈케이스에서 구독할 퍼블리셔입니다
+    var trainCarPublisher: AnyPublisher<TrainCar, Error> {
+        messageSubject.eraseToAnyPublisher()
+    }
+    
+    public init(stompClient: StompClientServiceProtocol) {
+        self.stompClient = stompClient
+        bindStompMessages()
+    }
+    
+    private func bindStompMessages() {
+        stompClient.messagePublisher
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { [weak self] completion in
+                if case let .failure(error) = completion {
+                    self?.messageSubject.send(completion: .failure(error))
+                }
+            }, receiveValue: { [weak self] stompMessage in
+                self?.handleStompMessage(stompMessage)
+            })
+            .store(in: &cancellables)
+    }
+    
+    private func handleStompMessage(_ message: StompTextMessageDTO) {
+        guard let data = message.text.data(using: .utf8) else {
+            messageSubject.send(completion: .failure(SeatCatcherDataError.nullValue))
+            return
+        }
+        
+        do {
+            let responseDTO = try decoder.decode(GetSeatInTrainCarResponseDTO.self, from: data)
+            let trainCar = responseDTO.domainModel
+            messageSubject.send(trainCar)
+        } catch {
+            messageSubject.send(completion: .failure(error))
+        }
+    }
+    
+    func subscribeToTrainCarSeats(trainCode: String) {
+        let topic = "/train/\(trainCode)"
+        stompClient.subscribe(topic: topic)
+    }
+    
+    func unsubscribeFromTrainCarSeats(trainCode: String) {
+        let topic = "/train/\(trainCode)"
+        stompClient.unsubscribe(topic: topic)
+    }
+}

--- a/SeatCatcherData/Sources/SeatCatcherData/Services/StompClientService.swift
+++ b/SeatCatcherData/Sources/SeatCatcherData/Services/StompClientService.swift
@@ -9,6 +9,18 @@ import Foundation
 import SwiftStomp
 import Combine
 
+protocol StompClientServiceProtocol {
+    var isConnectedPublisher: AnyPublisher<Bool, Never> { get }
+    var messagePublisher: AnyPublisher<StompTextMessageDTO, Never> { get }
+    func connect()
+    func disconnect()
+    func subscribe(topic: String)
+    func unsubscribe(topic: String)
+    func send(topic: String, message: String)
+}
+
+extension StompClientService: StompClientServiceProtocol {}
+
 /// 수신된 텍스트 메시지를 단순화한 데이터 모델
 struct StompTextMessageDTO {
     let text: String // 메시지 본문

--- a/SeatCatcherDomain/Sources/SeatCatcherDomain/Entities/Seat/Seat.swift
+++ b/SeatCatcherDomain/Sources/SeatCatcherDomain/Entities/Seat/Seat.swift
@@ -10,20 +10,17 @@ import Foundation
 public struct Seat: Sendable, Identifiable {
     
     public var id: Int // 좌석 식별자 (서버에서 제공)
-    public var isMySeat: Bool // 내가 앉아있는지 여부
     public var seatType: SeatType // 좌석 구분
     public var seatDirection: SeatDirection // UI 기준 좌석 방향
     public var occupant: Occupant? // 착석 유저 정보
 
     public init(
         id: Int,
-        isSeated: Bool,
         seatType: SeatType,
         seatDirection: SeatDirection,
         occupant: Occupant?
     ) {
         self.id = id
-        self.isMySeat = isSeated
         self.seatType = seatType
         self.seatDirection = seatDirection
         self.occupant = occupant

--- a/SeatCatcherDomain/Sources/SeatCatcherDomain/Entities/User/User.swift
+++ b/SeatCatcherDomain/Sources/SeatCatcherDomain/Entities/User/User.swift
@@ -8,13 +8,15 @@
 import Foundation
 
 public struct User: Sendable {
+    public var id: Int
     public var name: String
     public var profileImage: UserImage
     public var tags: [UserTag]
     public var credit: Int
     public var hasOnBoarded: Bool
 
-    public init(name: String, profileImage: UserImage, tags: [UserTag], credit: Int, hasOnBoarded: Bool) {
+    public init(id: Int, name: String, profileImage: UserImage, tags: [UserTag], credit: Int, hasOnBoarded: Bool) {
+        self.id = id
         self.name = name
         self.profileImage = profileImage
         self.tags = tags
@@ -23,6 +25,7 @@ public struct User: Sendable {
     }
 
     public init(hasOnBoarded: Bool) {
+        self.id = 0
         self.name = ""
         self.profileImage = .catchy1
         self.tags = []

--- a/SeatCatcherDomain/Sources/SeatCatcherDomain/Repositories/Seat/SeatStompRepository.swift
+++ b/SeatCatcherDomain/Sources/SeatCatcherDomain/Repositories/Seat/SeatStompRepository.swift
@@ -1,0 +1,16 @@
+//
+//  SeatStompRepository.swift
+//  SeatCatcherDomain
+//
+//  Created by 황채웅 on 6/3/25.
+//
+
+import Foundation
+import Combine
+
+/// STOMP를 통해 좌석 데이터를 처리하는 리포지토리 인터페이스
+public protocol SeatStompRepository {
+    var trainCarPublisher: AnyPublisher<TrainCar, Error> { get }
+    func subscribeToTrainCarSeats(trainCode: String)
+    func unsubscribeFromTrainCarSeats(trainCode: String)
+}

--- a/SeatCatcherDomain/Sources/SeatCatcherDomain/Repositories/Seat/SeatStompRepository.swift
+++ b/SeatCatcherDomain/Sources/SeatCatcherDomain/Repositories/Seat/SeatStompRepository.swift
@@ -10,7 +10,8 @@ import Combine
 
 /// STOMP를 통해 좌석 데이터를 처리하는 리포지토리 인터페이스
 public protocol SeatStompRepository {
-    var trainCarPublisher: AnyPublisher<TrainCar, Error> { get }
+    func trainCarPublisher(carCode: String) -> AnyPublisher<TrainCar, Error>
+    var isConnectedPublisher: AnyPublisher<Bool, Never> { get }
     func subscribeToTrainCarSeats(trainCode: String)
     func unsubscribeFromTrainCarSeats(trainCode: String)
 }

--- a/SeatCatcherDomain/Sources/SeatCatcherDomain/UseCases/Seat/SubscribeTrainUseCase.swift
+++ b/SeatCatcherDomain/Sources/SeatCatcherDomain/UseCases/Seat/SubscribeTrainUseCase.swift
@@ -1,0 +1,41 @@
+//
+//  SubscribeTrainUseCase.swift
+//  SeatCatcherDomain
+//
+//  Created by 황채웅 on 6/4/25.
+//
+
+import Foundation
+import Combine
+import SeatCatcherDomain
+
+public protocol SubscribeTrainUseCase {
+    func execute(trainCode: String, carCode: String) -> AnyPublisher<TrainCar, Error>
+    func connectionPublisher() -> AnyPublisher<Bool, Never>
+    func unsubscribe(trainCode: String)
+}
+
+public final class SubscribeTrainUseCaseImpl: SubscribeTrainUseCase {
+    private let seatStompRepository: SeatStompRepository
+    
+    public init(seatStompRepository: SeatStompRepository) {
+        self.seatStompRepository = seatStompRepository
+    }
+    
+    public func execute(trainCode: String, carCode: String) -> AnyPublisher<TrainCar, Error> {
+        subscribe(trainCode: trainCode) // trainCode 단위 구독 (열차 전체)
+        return seatStompRepository.trainCarPublisher(carCode: carCode) // 열차 -> 차량 필터링
+    }
+    
+    public func connectionPublisher() -> AnyPublisher<Bool, Never> {
+        seatStompRepository.isConnectedPublisher
+    }
+    
+    private func subscribe(trainCode: String) {
+        seatStompRepository.subscribeToTrainCarSeats(trainCode: trainCode)
+    }
+    
+    public func unsubscribe(trainCode: String) {
+        seatStompRepository.unsubscribeFromTrainCarSeats(trainCode: trainCode)
+    }
+}

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Common/Components/SeatSectionView.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Common/Components/SeatSectionView.swift
@@ -11,6 +11,7 @@ import SeatCatcherDomain
 public struct SeatSectionView: View {
     let selectedSeat: Seat?
     let isBlocked: Bool
+    let mySeat: Seat?
     let seats: SeatSection
     let userStatus: MainFeatureViewModel.UserStatus
     let onTap: (Seat) -> Void
@@ -24,6 +25,7 @@ public struct SeatSectionView: View {
             SeatRowView(
                 isBlocked: isBlocked,
                 seats: topSeats,
+                mySeat: mySeat,
                 selectedSeat: selectedSeat,
                 userStatus: userStatus,
                 onTap: onTap
@@ -32,6 +34,7 @@ public struct SeatSectionView: View {
             SeatRowView(
                 isBlocked: isBlocked,
                 seats: bottomSeats,
+                mySeat: mySeat,
                 selectedSeat: selectedSeat,
                 userStatus: userStatus,
                 onTap: onTap
@@ -51,6 +54,7 @@ public struct SeatSectionView: View {
 private struct SeatRowView: View {
     let isBlocked: Bool
     let seats: [Seat]
+    let mySeat: Seat?
     let selectedSeat: Seat?
     let userStatus: MainFeatureViewModel.UserStatus
     let onTap: (Seat) -> Void
@@ -62,7 +66,9 @@ private struct SeatRowView: View {
                     Image(seat.image(
                         isSelected: selectedSeat?.id == seat.id,
                         isBlocked: isBlocked && seat.occupant != nil,
-                        isSelecting: userStatus == .registering || userStatus == .moving)
+                        isSelecting: userStatus == .registering || userStatus == .moving,
+                        isMySeat: mySeat?.id == seat.id
+                    )
                     )
                     .frame(width: 40, height: 42)
                     .onTapGesture {
@@ -79,7 +85,7 @@ private struct SeatRowView: View {
     private func shouldShowSeat(seat: Seat) -> Bool {
         /// 좌석 이동/등록 시엔 점유된 좌석은 보여주지 않습니다
         if userStatus == .registering || userStatus == .moving {
-            return seat.occupant == nil || seat.isMySeat // 빈 좌석과 앉은 자리만 표시
+            return seat.occupant == nil || seat.id == mySeat?.id // 빈 좌석과 앉은 자리만 표시
         } else {
             return true  // 다른 상태에서는 모든 좌석 표시
         }

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureView.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureView.swift
@@ -26,6 +26,7 @@ public struct MainFeatureView: View {
             SeatSectionView(
                 selectedSeat: viewModel.state.seatSectionState.selectedSeat,
                 isBlocked: viewModel.state.seatSectionState.isBlocked,
+                mySeat: viewModel.state.seatSectionState.mySeat,
                 seats: viewModel.state.seatSectionState.seats,
                 userStatus: viewModel.state.userStatus,
                 onTap: { seat in
@@ -66,7 +67,7 @@ public struct MainFeatureView: View {
         .onChange(of: scenePhase) { _, newValue in
             if newValue == .background {
                 viewModel.action(.unsubscribe) // STOMP 연결 해제
-                // FIXME: AppDelegate 앱 종료 시로 수정 필요 
+                // FIXME: AppDelegate 앱 종료 시로 수정 필요
             }
         }
     }

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureView.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureView.swift
@@ -64,12 +64,6 @@ public struct MainFeatureView: View {
         .onAppear {
             viewModel.action(.willAppear)
         }
-        .onChange(of: scenePhase) { _, newValue in
-            if newValue == .background {
-                viewModel.action(.unsubscribe) // STOMP 연결 해제
-                // FIXME: AppDelegate 앱 종료 시로 수정 필요
-            }
-        }
     }
 }
 private struct TitleTextView: View {

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureView.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureView.swift
@@ -11,6 +11,7 @@ import SeatCatcherDomain
 
 public struct MainFeatureView: View {
     @State private var viewModel: MainFeatureViewModel
+    @Environment(\.scenePhase) private var scenePhase
 
     public init(viewModel: MainFeatureViewModel) {
         self._viewModel = State(initialValue: viewModel)
@@ -61,6 +62,12 @@ public struct MainFeatureView: View {
         )
         .onAppear {
             viewModel.action(.willAppear)
+        }
+        .onChange(of: scenePhase) { _, newValue in
+            if newValue == .background {
+                viewModel.action(.unsubscribe) // STOMP 연결 해제
+                // FIXME: AppDelegate 앱 종료 시로 수정 필요 
+            }
         }
     }
 }

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureViewModel.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureViewModel.swift
@@ -46,6 +46,7 @@ public final class MainFeatureViewModel: ViewModel {
     
     struct SeatSectionState {
         var selectedSeat: Seat? // 선택한 좌석
+        var mySeat: Seat? // 내가 앉은 좌석
         var isBlocked: Bool // 좌석 정보 잠금 상태
         var seats: SeatSection // 좌석 정보
     }
@@ -242,6 +243,7 @@ public final class MainFeatureViewModel: ViewModel {
                             trainCar: trainCar,
                             seatSectionType: state.seatSectionType
                         )
+                        self.state.seatSectionState.mySeat = self.findMySeat()
                     }
                 )
                 .store(in: &cancellables)
@@ -251,14 +253,14 @@ public final class MainFeatureViewModel: ViewModel {
                 .receive(on: DispatchQueue.main)
                 .sink { [weak self] isConnected in
                     guard let self else { return }
-                    state.showNoInformationToast = !isConnected
+                    dump("구독 상태 \(isConnected) - \(Date())")
                 }
                 .store(in: &cancellables)
         }
     }
     
     /// 구독 해제
-    private func unsubscribe() { // TODO: scenePhase와 연결하여 호출 필요
+    private func unsubscribe() { // TODO: AppDelegate와 연결하여 호출 필요
         if let subscribeTrainUseCase {
             subscribeTrainUseCase.unsubscribe(trainCode: state.trainCode)
             cancellables.removeAll()
@@ -292,21 +294,29 @@ public final class MainFeatureViewModel: ViewModel {
     private func fetchSeatInSection() {
         Task {
             do {
-                // 모든 구역의 좌석 데이터
+                /// 모든 구역의 좌석 데이터
                 let trainCar = try await getSeatInTrainCarUseCase.execute(trainCode: state.trainCode, carCode: state.carCode)
                 
-                // 현재 구역의 좌석 데이터만 필터링
+                /// 현재 구역의 좌석 데이터만 필터링
                 state.seatSectionState.seats = getSeatInSectionUseCase.execute(trainCar: trainCar, seatSectionType: state.seatSectionType)
                 
-                // 본인이 앉고 있는 좌석을 선택상태로 처리
+                /// 나의 좌석 반영
+                self.state.seatSectionState.mySeat = self.findMySeat()
+                
+                /// 나의 좌석 선택 처리 (좌석 등록 / 이동 시)
                 if state.userStatus == .registering || state.userStatus == .moving {
-                    state.seatSectionState.selectedSeat = state.seatSectionState.seats.topSeats.values.first { $0.isMySeat }
-                    ?? state.seatSectionState.seats.bottomSeats.values.first { $0.isMySeat }
+                    self.state.seatSectionState.selectedSeat = self.state.seatSectionState.mySeat
                 }
+
             } catch {
                 print(error.localizedDescription)
             }
         }
+    }
+    
+    private func findMySeat() -> Seat? {
+        return state.seatSectionState.seats.topSeats.values.first { $0.occupant?.id == store.user.id }
+        ?? state.seatSectionState.seats.bottomSeats.values.first { $0.occupant?.id == store.user.id }
     }
     
     private func registerSeat(_ seat: Seat) {

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureViewModel.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureViewModel.swift
@@ -25,6 +25,7 @@ public final class MainFeatureViewModel: ViewModel {
         case willCancelSeat // 좌석 취소
         case backToSeatSectionPage // 좌석 구역 페이지로 이동
         case manageSeatSection(SeatSectionAction)
+        case unsubscribe // STOMP 연결 해제
     }
     
     enum SeatSectionAction {
@@ -213,6 +214,8 @@ public final class MainFeatureViewModel: ViewModel {
             cancelSeat()
         case .backToSeatSectionPage:
             coordinator.pop()
+        case .unsubscribe:
+            unsubscribe()
         }
     }
     

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureViewModel.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureViewModel.swift
@@ -25,7 +25,6 @@ public final class MainFeatureViewModel: ViewModel {
         case willCancelSeat // 좌석 취소
         case backToSeatSectionPage // 좌석 구역 페이지로 이동
         case manageSeatSection(SeatSectionAction)
-        case unsubscribe // STOMP 연결 해제
     }
     
     enum SeatSectionAction {
@@ -215,8 +214,6 @@ public final class MainFeatureViewModel: ViewModel {
             cancelSeat()
         case .backToSeatSectionPage:
             coordinator.pop()
-        case .unsubscribe:
-            unsubscribe()
         }
     }
     
@@ -260,7 +257,7 @@ public final class MainFeatureViewModel: ViewModel {
     }
     
     /// 구독 해제
-    private func unsubscribe() { // TODO: AppDelegate와 연결하여 호출 필요
+    private func unsubscribe() { // TODO: - 백그라운드에서도 연결 유지해야하므로 추후 검토 후 삭제
         if let subscribeTrainUseCase {
             subscribeTrainUseCase.unsubscribe(trainCode: state.trainCode)
             cancellables.removeAll()

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureViewModel.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Combine
 import SeatCatcherCore
 import SeatCatcherDomain
 
@@ -48,6 +49,9 @@ public final class MainFeatureViewModel: ViewModel {
         var seats: SeatSection // 좌석 정보
     }
     
+    // MARK: Cancellables
+    private var cancellables = Set<AnyCancellable>()
+    
     // MARK: Dependencies
     let store: AppStore
     let coordinator: Coordinator
@@ -64,6 +68,7 @@ public final class MainFeatureViewModel: ViewModel {
     private let registerSeatUseCase: RegisterSeatUseCase?
     private let moveSeatUseCase: MoveSeatUseCase?
     private let cancelSeatUseCase: CancelSeatUseCase?
+    private let subscribeTrainUseCase: SubscribeTrainUseCase?
     
     
     // MARK: Initialize
@@ -73,6 +78,7 @@ public final class MainFeatureViewModel: ViewModel {
         getSeatInTrainCarUseCase: GetSeatInTrainCarUseCase,
         getSeatInSectionUseCase: GetSeatInSectionUseCase,
         unlockSeatUseCase: UnlockSeatUseCase,
+        subscribeTrainUseCase: SubscribeTrainUseCase? = nil,
         registerSeatUseCase: RegisterSeatUseCase? = nil,
         moveSeatUseCase: MoveSeatUseCase? = nil,
         cancelSeatUseCase: CancelSeatUseCase? = nil,
@@ -83,6 +89,7 @@ public final class MainFeatureViewModel: ViewModel {
         self.getSeatInTrainCarUseCase = getSeatInTrainCarUseCase
         self.getSeatInSectionUseCase = getSeatInSectionUseCase
         self.unlockSeatUseCase = unlockSeatUseCase
+        self.subscribeTrainUseCase = subscribeTrainUseCase
         self.registerSeatUseCase = registerSeatUseCase
         self.moveSeatUseCase = moveSeatUseCase
         self.cancelSeatUseCase = cancelSeatUseCase
@@ -108,7 +115,8 @@ public final class MainFeatureViewModel: ViewModel {
         coordinator: Coordinator,
         getSeatInTrainCarUseCase: GetSeatInTrainCarUseCase,
         getSeatInSectionUseCase: GetSeatInSectionUseCase,
-        unlockSeatUseCase: UnlockSeatUseCase
+        unlockSeatUseCase: UnlockSeatUseCase,
+        subscribeTrainUseCase: SubscribeTrainUseCase
     ) {
         self.init(
             store: store,
@@ -116,6 +124,7 @@ public final class MainFeatureViewModel: ViewModel {
             getSeatInTrainCarUseCase: getSeatInTrainCarUseCase,
             getSeatInSectionUseCase: getSeatInSectionUseCase,
             unlockSeatUseCase: unlockSeatUseCase,
+            subscribeTrainUseCase: subscribeTrainUseCase,
             userStatus: store.isSitting ? .seated : .standing
         )
     }
@@ -185,6 +194,9 @@ public final class MainFeatureViewModel: ViewModel {
         switch action {
         case .willAppear:
             fetchSeatInSection()
+            if state.userStatus == .standing || state.userStatus == .seated {
+                subscribeToTrainSeats()
+            }
         case let .manageSeatSection(seatSectionAction):
             handleSeatSectionAction(seatSectionAction)
         case .backButtonDidTap:
@@ -201,6 +213,52 @@ public final class MainFeatureViewModel: ViewModel {
             cancelSeat()
         case .backToSeatSectionPage:
             coordinator.pop()
+        }
+    }
+    
+    /// 메인피쳐 기본 상태일 시에만 수행합니다
+    /// 좌석 등록 / 이동 / 취소 시엔 STOMP 없이 REST API만 작동합니다
+    private func subscribeToTrainSeats() {
+        if let subscribeTrainUseCase {
+            /// 차량 좌석 업데이트 이벤트를 구독합니다
+            subscribeTrainUseCase.execute(trainCode: state.trainCode, carCode: state.carCode)
+                .receive(on: DispatchQueue.main)
+                .sink(
+                    receiveCompletion: { [weak self] completion in
+                        guard let self else { return }
+                        if case let .failure(error) = completion {
+                            state.showNoInformationToast = true
+                            print(error.localizedDescription)
+                        }
+                    },
+                    receiveValue: { [weak self] trainCar in
+                        /// 열차 -> 차량 필터링 된 이벤트
+                        guard let self else { return }
+                        /// 차량 -> 구역 필터링
+                        state.seatSectionState.seats = getSeatInSectionUseCase.execute(
+                            trainCar: trainCar,
+                            seatSectionType: state.seatSectionType
+                        )
+                    }
+                )
+                .store(in: &cancellables)
+            
+            /// 연결 상태를 구독합니다
+            subscribeTrainUseCase.connectionPublisher()
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] isConnected in
+                    guard let self else { return }
+                    state.showNoInformationToast = !isConnected
+                }
+                .store(in: &cancellables)
+        }
+    }
+    
+    /// 구독 해제
+    private func unsubscribe() { // TODO: scenePhase와 연결하여 호출 필요
+        if let subscribeTrainUseCase {
+            subscribeTrainUseCase.unsubscribe(trainCode: state.trainCode)
+            cancellables.removeAll()
         }
     }
     

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Helper/Seat+.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Helper/Seat+.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 extension Seat {
     
-    func image(isSelected: Bool, isBlocked: Bool, isSelecting: Bool) -> ImageResource {
+    func image(isSelected: Bool, isBlocked: Bool, isSelecting: Bool, isMySeat: Bool) -> ImageResource {
         // 좌석 방향
         let directionPrefix = seatDirection == .top ? "seat_top" : "seat_bottom"
         


### PR DESCRIPTION
## ✅ Description

- ### Websocket 좌석 정보 업데이트 로직 구현
  초기 `fetch`시 REST API에선 해당 차량(carCode)의 좌석 정보만 페칭 받습니다
  이후 구독은 열차(`trainCode`)로 요청하기 때문에,
  모든 차량(`carCode`)의 전체 좌석 정보가 한꺼번에 넘어옵니다
  하지만 아직 로직상 다른 차량의 정보는 필요 없으므로 (추후 확장성을 위해 회의 시 `trainCode`만의 구독을 선택)
  `SeatStompRepositoryImpl`에서 주입한 `carCode`와 일치하는 좌석정보의 업데이트 이벤트만 전달하도록 하였습니다

- `isMySeat`를 `Seat` 엔티티에서 제거하였습니다
  -> 뷰모델에서 `findMySeat()`로 수행 
  -> `Seat+` 익스텐션의 좌석 이미지 함수 파라미터 나의 좌석 여부 주입
  (리스폰스의 `occupant` - `id`와 `AppStore` - `User` - `id` 프로퍼티와 비교)

### TODO
- STOMP 구독 해제 로직 `AppDelegate` 앱 종료시와 연동 필요
  (현재는 scenePhase - background와 임시로 연결)

## ⭐️ PR Point
<!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
- 아직 테스트는 못해본 상황입니다
- 혹시 로직 상에 문제가 있으면 피드백 부탁드려요~

## 📸 Simulator


## 💡 Issue
- Resolved: #47 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 실시간 좌석 정보 구독 기능이 추가되어, 열차 및 객차별 좌석 현황이 실시간으로 반영됩니다.
    - 사용자 본인의 좌석 정보가 별도로 표시됩니다.
    - 앱이 백그라운드로 전환될 때 실시간 좌석 정보 구독이 자동 해제됩니다.
    - 좌석 데이터 수신 오류에 대한 안내 메시지가 추가되었습니다.

- **버그 수정**
    - 실시간 연결 상태 변화에 따라 안내 토스트가 표시됩니다.

- **기타**
    - 실시간 좌석 데이터 처리를 위한 내부 구조가 개선되었습니다.
    - 사용자 식별 및 좌석 상태 표현 방식이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->