### PR TITLE
[#58] AccessTokenProvider 초기화 시점 조정

### DIFF
--- a/SeatCatcher/SeatCatcher/Sources/App/DIContainer/DIContainerImpl.swift
+++ b/SeatCatcher/SeatCatcher/Sources/App/DIContainer/DIContainerImpl.swift
@@ -23,11 +23,11 @@ final class DIContainerImpl {
     private let stompClientService = StompClientService()
 
     // MARK: - Provider Instances
-    private lazy var accessTokenProvider = AccessTokenProvider(tokenRepository: tokenRepository, stompService: stompClientService)
+    private let accessTokenProvider: AccessTokenProvider
 
     // MARK: - Repository Instances
     private lazy var loginRepository = LoginRepositoryImpl(networkService: networkService)
-    private lazy var tokenRepository = TokenRepositoryImpl(networkService: networkService)
+    private let tokenRepository: TokenRepository
     private lazy var userRepository = UserRepositoryImpl(networkService: networkService)
     private lazy var stationsRepository = StationsRepositoryImpl(networkService: networkService)
     private lazy var pathHistoriesRepository = PathHistoriesRepositoryImpl(
@@ -89,6 +89,15 @@ final class DIContainerImpl {
 
     // MARK: - Incomings UseCase Instances
     private lazy var getIncomingsUseCase = GetIncomingsUseCaseImpl(incomingsRepository: incomingsRepository)
+
+    init() {
+        self.tokenRepository = TokenRepositoryImpl(networkService: networkService)
+
+        self.accessTokenProvider = AccessTokenProvider(
+            tokenRepository: tokenRepository,
+            stompService: stompClientService
+        )
+    }
 }
 
 // MARK: - DIContainer 프로토콜 구현


### PR DESCRIPTION
## ✅ Description
- DIContainerImpl 내부 AccessTokenProvider 초기화 시점을 조정했습니다.
    - 기존 accessTokenProvider 프로퍼티가 lazy var로 선언되어 있었는데, 해당 프로퍼티를 참조하는 곳이 없어 인스턴스가 생성되지 않았고, publisher가 방출한 accessToken을 수신할 수 없어 웹소켓 헤더가 교체되지 않는 버그를 발견했습니다.
    - let으로 변경하여 DIContainerImpl 초기화 시 accessTokenProvider가 생성되도록 변경했습니다.
- 수정 후 정상적으로 재연결되는 것을 확인했습니다.

## ⭐️ PR Point
<!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
- 머지된 상태로 TestFlight에 빌드를 업로드하기 위해 빠르게 머지하겠습니다! 내일 일어나시면 확인해 주세요

## 💡 Issue
- Resolved: #58


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - 내부 의존성 초기화 방식을 개선하여 앱의 안정성과 성능을 향상시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->