### PR TITLE
[#60] 메인피처 플로우 연동

### DIFF
--- a/SeatCatcher/SeatCatcher/Resources/Plists/Info.plist
+++ b/SeatCatcher/SeatCatcher/Resources/Plists/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>KAKAO_APP_KEY</key>
 	<string>$(KAKAO_APP_KEY)</string>
 	<key>CFBundleURLTypes</key>

--- a/SeatCatcher/SeatCatcher/Sources/App/Coordinator/AppCoordinator.swift
+++ b/SeatCatcher/SeatCatcher/Sources/App/Coordinator/AppCoordinator.swift
@@ -242,20 +242,12 @@ final class AppCoordinator: Coordinator {
             case let .requestRejected(confirmationButtonAction):
                 RequestRejectedBottomSheetView(confirmationButtonAction: confirmationButtonAction)
             case let .seatInfo(
-                name,
-                userImage,
-                tags,
-                arrivalStationName,
-                expectedArrivalTime,
+                occupant,
                 reportButtonAction,
                 yieldButtonAction
             ):
                 SeatInfoBottomSheetView(
-                    name: name,
-                    userImage: userImage,
-                    tags: tags,
-                    arrivalStationName: arrivalStationName,
-                    expectedArrivalTime: expectedArrivalTime,
+                    occupant: occupant,
                     reportButtonAction: reportButtonAction,
                     yieldButtonAction: yieldButtonAction
                 )

--- a/SeatCatcherCore/Sources/SeatCatcherCore/Coordinator/Coordinator.swift
+++ b/SeatCatcherCore/Sources/SeatCatcherCore/Coordinator/Coordinator.swift
@@ -20,6 +20,7 @@ public protocol Coordinator: AnyObject {
     func push(_ scene: any AppRoute)
     func pop()
     func popToRoot()
+    func popLast(_ count: Int)
     func presentSheet(_ sheet: any AppRoute, onDismiss: (() -> Void)?)
     func dismissSheet()
     func presentFullScreenCover(
@@ -37,6 +38,12 @@ public extension Coordinator {
 
     func pop() {
         if !path.isEmpty { path.removeLast() }
+    }
+    
+    func popLast(_ count: Int) {
+        for _ in 0..<count {
+            if !path.isEmpty { path.removeLast() }
+        }
     }
 
     func popToRoot() {

--- a/SeatCatcherCore/Sources/SeatCatcherCore/Store/AppStore.swift
+++ b/SeatCatcherCore/Sources/SeatCatcherCore/Store/AppStore.swift
@@ -29,7 +29,7 @@ public final class AppStore {
     public var carDirection: CarDirection? { incoming?.carDirection } // 하행 상행 구분
     public var isSitting: Bool // 앉아있음 여부
     /// 메인피쳐 좌석 정보 업데이트에 필요한 열차 좌석 정보 퍼블리셔입니다
-    private var trainCar: TrainCar? {
+    public var trainCar: TrainCar? {
         didSet {
             _trainCarPublisher.send(trainCar)
         }
@@ -101,12 +101,14 @@ public final class AppStore {
             .sink(
                 receiveCompletion: { completion in
                     if case let .failure(error) = completion {
-                        dump("열차 정보 오류: \(error.localizedDescription)")
+                        dump("열차 정보 오류: \(error)")
                     }
                 },
                 receiveValue: { [weak self] trainCar in
-                    guard self?.trainCar != trainCar else { return }
+//                    guard self?.trainCar != trainCar else { return }
+//                    dump(trainCar)
                     self?.trainCar = trainCar
+                    dump(self?.trainCar)
                 }
             )
             .store(in: &trainCarCancellables)

--- a/SeatCatcherData/Sources/SeatCatcherData/DTOs/Trains/GetSeatInTrainCarResponseDTO.swift
+++ b/SeatCatcherData/Sources/SeatCatcherData/DTOs/Trains/GetSeatInTrainCarResponseDTO.swift
@@ -24,9 +24,9 @@ struct SeatInfo: Codable {
 struct OccupantInfo: Codable {
     let userId: Int
     let nickname: String
-    let getOffRemainingCount: Int
-    let profileImage: String // FIXME: 서버 작업 중
-    let getOffStation: String // FIXME: 서버 작업 중
+    let getOffRemainingCount: Int?
+    let profileImageNum: String // FIXME: 서버 작업 중
+    let getOffStation: String? // FIXME: 서버 작업 중
     let tags: [String] // FIXME: 서버 작업 중
     
     static var stub: Self {
@@ -34,7 +34,7 @@ struct OccupantInfo: Codable {
             userId: 1,
             nickname: "신기한 발바닥",
             getOffRemainingCount: 33,
-            profileImage: "IMAGE_1",
+            profileImageNum: "IMAGE_1",
             getOffStation: "상도역",
             tags: ["USERTAG_LONGDISTANCE", "USERTAG_CARRIER"]
         )
@@ -192,10 +192,10 @@ extension OccupantInfo {
         Occupant(
             id: userId,
             name: nickname,
-            profileImage: UserImage(rawValue: profileImage) ?? .catchy1,
+            profileImage: UserImage(rawValue: profileImageNum) ?? .catchy1,
             tags: tags.compactMap { UserTag(rawValue: $0) },
-            minutesLeftToGetOff: getOffRemainingCount,
-            stationToGetOff: getOffStation
+            minutesLeftToGetOff: getOffRemainingCount ?? 0,
+            stationToGetOff: getOffStation ?? ""
         )
     }
 }

--- a/SeatCatcherData/Sources/SeatCatcherData/Network/Moya/SeatCatcherAPI.swift
+++ b/SeatCatcherData/Sources/SeatCatcherData/Network/Moya/SeatCatcherAPI.swift
@@ -170,7 +170,16 @@ extension SeatCatcherAPI: TargetType {
         case let .getSeatInfo(trainCode, carCode):
             return .requestParameters(parameters: ["trainCode": trainCode, "carCode": carCode], encoding: URLEncoding.default)
         case let .postRegisterSeat(requestDTO):
-            return .requestJSONEncodable(requestDTO)
+            let parameters: [String: Any] = [
+                "seatId": requestDTO.seatId,
+                "creditAmount": requestDTO.creditAmount
+            ]
+            dump(parameters)
+
+            return .requestParameters(
+                parameters: parameters,
+                encoding: URLEncoding.queryString
+            )
         case .deleteSeat:
             return .requestPlain
         case let .getIncomings(requestDTO):

--- a/SeatCatcherData/Sources/SeatCatcherData/Repositories/PathHistories/PathHistoriesRepositoryImpl.swift
+++ b/SeatCatcherData/Sources/SeatCatcherData/Repositories/PathHistories/PathHistoriesRepositoryImpl.swift
@@ -48,6 +48,7 @@ public final class PathHistoriesRepositoryImpl: PathHistoriesRepository {
         let arrivalTimePublisher = stompClientService
             .messagePublisher
             .compactMap { message -> PathArrivalTime? in
+                dump(message)
                 guard let data = message.text.data(using: .utf8),
                       let dto = try? JSONDecoder().decode(ArrivalTimeDTO.self, from: data),
                       let date = dateFormatter.date(from: dto.expectedArrivalTime)

--- a/SeatCatcherData/Sources/SeatCatcherData/Repositories/Station/StationsRepositoryImpl.swift
+++ b/SeatCatcherData/Sources/SeatCatcherData/Repositories/Station/StationsRepositoryImpl.swift
@@ -16,6 +16,7 @@ public final class StationsRepositoryImpl: StationsRepository {
 
     public func getStations(keyword: String, line: Int) async throws -> [Station] {
         let responseDTO = try await networkService.getStations(keyword: keyword, line: line)
+        dump(responseDTO)
         return responseDTO.map { $0.domainModel }
     }
 

--- a/SeatCatcherData/Sources/SeatCatcherData/Services/NetworkService.swift
+++ b/SeatCatcherData/Sources/SeatCatcherData/Services/NetworkService.swift
@@ -218,6 +218,7 @@ public struct NetworkService: Sendable {
             endStationId: arrivalStationId,
             trainCode: trainCode
         )
+        dump(requestDTO)
         let response = try await provider.request(.postStartJourney(requestDTO: requestDTO))
         let responseDTO = try JSONDecoder().decode(PostStartJourneyResponseDTO.self, from: response)
         return responseDTO
@@ -227,12 +228,14 @@ public struct NetworkService: Sendable {
     func getSeatsInTrainCar(trainCode: String, carCode: String) async throws -> GetSeatInTrainCarResponseDTO {
         let response = try await provider.request(.getSeatInfo(trainCode: trainCode, carCode: carCode))
         let responseDTO = try JSONDecoder().decode(GetSeatInTrainCarResponseDTO.self, from: response)
+        dump(responseDTO)
         return responseDTO
     }
     
     // MARK: - Seats
     func registerSeat(seatId: Int, creditAmount: Int) async throws {
         let requestDTO = PostRegisterSeatRequestDTO(seatId: seatId, creditAmount: creditAmount)
+        dump(requestDTO)
         try await provider.request(.postRegisterSeat(requestDTO: requestDTO))
     }
     func cancelSeat() async throws {

--- a/SeatCatcherDomain/Sources/SeatCatcherDomain/Entities/Occupant/Occupant.swift
+++ b/SeatCatcherDomain/Sources/SeatCatcherDomain/Entities/Occupant/Occupant.swift
@@ -7,7 +7,12 @@
 
 import Foundation
 
-public struct Occupant: Sendable {
+public struct Occupant: Sendable, Equatable {
+    
+    public static func == (lhs: Occupant, rhs: Occupant) -> Bool {
+        return lhs.id == rhs.id && lhs.minutesLeftToGetOff == rhs.minutesLeftToGetOff && lhs.stationToGetOff == rhs.stationToGetOff
+    }
+    
     public var id: Int // 유저 id(서버)
     public var name: String // 닉네임
     public var profileImage: UserImage // 프로필 사진

--- a/SeatCatcherDomain/Sources/SeatCatcherDomain/Entities/Seat/Seat.swift
+++ b/SeatCatcherDomain/Sources/SeatCatcherDomain/Entities/Seat/Seat.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public struct Seat: Sendable, Identifiable, Equatable {
     public static func == (lhs: Seat, rhs: Seat) -> Bool {
-        return lhs.id == rhs.id
+        return lhs.id == rhs.id && lhs.occupant == rhs.occupant
     }
     
     public var id: Int // 좌석 식별자 (서버에서 제공)

--- a/SeatCatcherDomain/Sources/SeatCatcherDomain/UseCases/Seat/CancelSeatUseCase.swift
+++ b/SeatCatcherDomain/Sources/SeatCatcherDomain/UseCases/Seat/CancelSeatUseCase.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public protocol CancelSeatUseCase {
-    func execute(_ seat: Seat) async throws
+    func execute(_ seat: Seat?) async throws
 }
 
 public final class CancelSeatUseCaseImpl: CancelSeatUseCase {
@@ -21,10 +21,12 @@ public final class CancelSeatUseCaseImpl: CancelSeatUseCase {
         self.seatStompRepository = seatStompRepository
     }
     
-    public func execute(_ seat: Seat) async throws {
+    public func execute(_ seat: Seat? = nil) async throws {
         /// 좌석 점유를 해제합니다
         try await seatRepository.cancelSeat()
         /// 좌석 요청에 대한 구독을 취소합니다
-        seatStompRepository.unsubscribeFromSeatOccupied(seat)
+        if let seat {
+            seatStompRepository.unsubscribeFromSeatOccupied(seat)
+        }
     }
 }

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/BottomSheet/New/SeatInfoBottomSheetView.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/BottomSheet/New/SeatInfoBottomSheetView.swift
@@ -10,32 +10,21 @@ import SeatCatcherDomain
 import SwiftUI
 
 public struct SeatInfoBottomSheetView: View {
-    let name: String
-    let userImage: UserImage
-    let tags: [UserTag]
-    let arrivalStationName: String
-    let expectedArrivalTime: Date
+    let occupant: Occupant
     let reportButtonAction: () -> Void
     let yieldButtonAction: () -> Void
 
-    var remainingMinutes: Int {
-        max(Int(expectedArrivalTime.timeIntervalSinceNow / 60), 0)
-    }
+    // FIXME: - 실제 하차역으로 교체 서버에서 안옴
+    let dummyDest = ["건대입구", "대림"].randomElement()!
+    // FIXME: - 실제 하차역으로 교체 서버에서 안옴
+    let dummyTime = (3...45).randomElement()!
 
     public init(
-        name: String,
-        userImage: UserImage,
-        tags: [UserTag],
-        arrivalStationName: String,
-        expectedArrivalTime: Date,
+        occupant: Occupant,
         reportButtonAction: @escaping () -> Void,
         yieldButtonAction: @escaping () -> Void
     ) {
-        self.name = name
-        self.userImage = userImage
-        self.tags = tags
-        self.arrivalStationName = arrivalStationName
-        self.expectedArrivalTime = expectedArrivalTime
+        self.occupant = occupant
         self.reportButtonAction = reportButtonAction
         self.yieldButtonAction = yieldButtonAction
     }
@@ -43,17 +32,17 @@ public struct SeatInfoBottomSheetView: View {
     public var body: some View {
         VStack(spacing: 0) {
             HStack(spacing: 6) {
-                Image(userImage.image)
+                Image(occupant.profileImage.image)
                     .resizable()
                     .frame(width: 68, height: 68)
                 VStack(spacing: 6) {
-                    Text(name)
+                    Text(occupant.name)
                         .font(.B03_M)
                         .foregroundStyle(.gray300)
                         .frame(maxWidth: .infinity, alignment: .leading)
                     ScrollView(.horizontal) {
                         HStack(spacing: 6) {
-                            ForEach(tags) {
+                            ForEach(occupant.tags) {
                                 UserInfoBadge(.tag($0))
                             }
                         }
@@ -87,8 +76,11 @@ public struct SeatInfoBottomSheetView: View {
 
                 VStack(alignment: .leading, spacing: 12) {
                     Group {
-                        Text("\(arrivalStationName)역")
-                        Text("\(remainingMinutes)분 남았어요")
+                        // FIXME: - 실제 하차역으로 교체 서버에서 안옴
+                        Text("\(dummyDest)역")
+                        // FIXME: - 실제 남은시간으로 교체 서버에서 안옴
+                        Text("\(dummyTime)분 남았어요")
+//                        Text("\(occupant.minutesLeftToGetOff)분 남았어요")
                     }
                     .font(.B02_M)
                     .foregroundStyle(.gray100)
@@ -97,7 +89,9 @@ public struct SeatInfoBottomSheetView: View {
             }
 
             CTAButton(
-                title: "양보 요청하기",
+                // FIXME: - 양보 요청하기 버튼으로 변경
+//                title: "양보 요청하기",
+                title: "확인",
                 action: yieldButtonAction,
                 style: .bottomEnabled
             )

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureView.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureView.swift
@@ -25,7 +25,7 @@ public struct MainFeatureView: View {
             SeatSectionView(
                 selectedSeat: viewModel.state.seatSectionState.selectedSeat,
                 isBlocked: viewModel.state.seatSectionState.isBlocked,
-                userId: viewModel.store.user.id,
+                mySeat: viewModel.state.seatSectionState.mySeat,
                 seats: viewModel.state.seatSectionState.seats,
                 userStatus: viewModel.state.userStatus,
                 onTap: { seat in

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureView.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureView.swift
@@ -186,10 +186,8 @@ private struct CTAButtonView: View {
                     if let seat = viewModel.state.seatSectionState.selectedSeat {
                         viewModel.action(.willMoveSeat(seat))
                     }
-                case .cancelling:
-                    if let seat = viewModel.state.seatSectionState.mySeat {
-                        viewModel.action(.willCancelSeat(seat))
-                    }
+                case .cancelling:    
+                    viewModel.action(.willCancelSeat(viewModel.state.seatSectionState.mySeat))
                 }
             },
             style: ctaButtonStyle

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureView.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureView.swift
@@ -25,7 +25,7 @@ public struct MainFeatureView: View {
             SeatSectionView(
                 selectedSeat: viewModel.state.seatSectionState.selectedSeat,
                 isBlocked: viewModel.state.seatSectionState.isBlocked,
-                mySeat: viewModel.state.seatSectionState.mySeat,
+                userId: viewModel.store.user.id,
                 seats: viewModel.state.seatSectionState.seats,
                 userStatus: viewModel.state.userStatus,
                 onTap: { seat in
@@ -58,6 +58,15 @@ public struct MainFeatureView: View {
                 backButtonAction: { viewModel.action(.backButtonDidTap) },
                 homeButtonAction: { viewModel.action(.homeButtonDidTap) },
                 applyDefaultPopAction: false
+            )
+        )
+        .alert(
+            viewModel.state.isReportAlertPresented,
+            alert: .init(
+                title: "신고가 접수되었어요",
+                subtitle: "빠른 시일 내에 처리될 예정이에요",
+                buttonTitle: "확인",
+                buttonAction: { viewModel.action(.reportAlertConfirmButtonDidTap) }
             )
         )
         .onAppear {

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureViewModel.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureViewModel.swift
@@ -25,6 +25,8 @@ public final class MainFeatureViewModel: ViewModel {
         case backToSeatSectionPage // 좌석 구역 페이지로 이동
         case manageSeatSection(SeatSectionAction) // 좌석 관리 액션 수행
         case manageSeatRequest(SeatRequestAction) // 좌석 요청 관련 액션 수행
+        case reportButtonDidTap // 바텀시트 신고버튼
+        case reportAlertConfirmButtonDidTap // 바텀시트 신고 후 알럿 버튼
     }
     
     enum SeatSectionAction {
@@ -49,6 +51,8 @@ public final class MainFeatureViewModel: ViewModel {
         var lookingCount: Int // 현재 열차 내 자리를 찾는 사용자 수, 0의 경우 띄우지 않음
         var seatSectionState: SeatSectionState
         var seatRequestState: SeatRequestState
+        var isSeatFetched = false
+        var isReportAlertPresented = false // 신고 alert
     }
     
     struct SeatSectionState {
@@ -69,7 +73,11 @@ public final class MainFeatureViewModel: ViewModel {
     // MARK: Dependencies
     let store: AppStore
     let coordinator: Coordinator
-    
+
+
+
+
+
     // MARK: States
     private(set) var state: State
     
@@ -241,7 +249,7 @@ public final class MainFeatureViewModel: ViewModel {
     func action(_ action: Action) {
         switch action {
         case .willAppear:
-            fetchSeatInSection()
+            if !state.isSeatFetched { fetchSeatInSection() }
             if state.userStatus == .standing || state.userStatus == .seated {
                 subscribeToTrain(trainCode: state.trainCode, carCode: state.carCode)
                 setupStoreObservers()
@@ -273,6 +281,11 @@ public final class MainFeatureViewModel: ViewModel {
             case let .willRejectSeatRequest(seat, requester):
                 rejectSeatRequest(seat, requester: requester)
             }
+        case .reportButtonDidTap:
+            coordinator.dismissSheet()
+            state.isReportAlertPresented = true
+        case .reportAlertConfirmButtonDidTap:
+            state.isReportAlertPresented = false
         }
     }
     
@@ -343,16 +356,37 @@ public final class MainFeatureViewModel: ViewModel {
     
     @MainActor
     private func handleSeatSectionAction(_ action: SeatSectionAction) {
+        dump(state.userStatus)
         switch action {
         case .willSelectSeat(let seat):
-            /// 좌석을 선택합니다
-            if state.userStatus != .cancelling { // 좌석 취소 중에는 선택 불가
-                if state.seatSectionState.selectedSeat?.id == seat.id {
-                    state.seatSectionState.selectedSeat = nil
-                } else {
-                    state.seatSectionState.selectedSeat = seat
+            switch state.userStatus {
+            case .seated:
+                dump(#function)
+            case .standing:
+                guard let occupant = seat.occupant else { return }
+                // FIXME: - occupant 없을 시 방지
+                // FIXME: - 실제 seat의 occupant로 교체
+                coordinator.presentSheet(
+                    AppSheet.seatInfo(
+                        occupant: occupant,
+                        reportButtonAction: {
+                            self.action(.reportButtonDidTap)
+                        },
+                        // FIXME: - 양보 로직 달기
+                        yieldButtonAction: { self.coordinator.dismissSheet() }
+                    )
+                )
+            case .registering, .moving, .cancelling:
+                // 좌석을 선택합니다
+                if state.userStatus != .cancelling { // 좌석 취소 중에는 선택 불가
+                    if state.seatSectionState.selectedSeat?.id == seat.id {
+                        state.seatSectionState.selectedSeat = nil
+                    } else {
+                        state.seatSectionState.selectedSeat = seat
+                    }
                 }
             }
+
         case .willUnlockAllSeats:
             /// 좌석 정보를 잠금 해제합니다
             Task {
@@ -374,6 +408,7 @@ public final class MainFeatureViewModel: ViewModel {
         let currentSeatSectionType = state.seatSectionType
         let currentUserStatus = state.userStatus
         Task {
+            defer { state.isSeatFetched = true }
             do {
                 let trainCar = try await getSeatInTrainCarUseCase.execute(trainCode: currentTrainCode, carCode: currentCarCode)
                 await MainActor.run {
@@ -381,7 +416,7 @@ public final class MainFeatureViewModel: ViewModel {
                     state.carCode == currentCarCode else { return }
                     /// 현재 구역의 좌석 데이터만 필터링
                     state.seatSectionState.seats = getSeatInSectionUseCase.execute(trainCar: trainCar, seatSectionType: currentSeatSectionType)
-                    
+
                     /// 나의 좌석 반영
                     state.seatSectionState.mySeat = findMySeat()
                     
@@ -414,6 +449,7 @@ public final class MainFeatureViewModel: ViewModel {
                 } catch {
                     print(error.localizedDescription)
                 }
+                coordinator.popToRoot()
             }
         }
     }
@@ -429,6 +465,7 @@ public final class MainFeatureViewModel: ViewModel {
                 } catch {
                     print(error.localizedDescription)
                 }
+                coordinator.popToRoot()
             }
         }
     }
@@ -443,6 +480,7 @@ public final class MainFeatureViewModel: ViewModel {
                 } catch {
                     print(error.localizedDescription)
                 }
+                coordinator.popToRoot()
             }
         }
     }
@@ -503,7 +541,9 @@ public final class MainFeatureViewModel: ViewModel {
             }
         }
     }
-    
+
+
+
     public enum UserStatus: Sendable {
         case seated // 착석 중
         case standing // 자리 찾는 중

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureViewModel.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureViewModel.swift
@@ -449,7 +449,7 @@ public final class MainFeatureViewModel: ViewModel {
                 } catch {
                     print(error.localizedDescription)
                 }
-                coordinator.popToRoot()
+                coordinator.popLast(2)
             }
         }
     }
@@ -465,7 +465,7 @@ public final class MainFeatureViewModel: ViewModel {
                 } catch {
                     print(error.localizedDescription)
                 }
-                coordinator.popToRoot()
+                coordinator.popLast(2)
             }
         }
     }
@@ -480,7 +480,7 @@ public final class MainFeatureViewModel: ViewModel {
                 } catch {
                     print(error.localizedDescription)
                 }
-                coordinator.popToRoot()
+                coordinator.popLast(2)
             }
         }
     }

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureViewModel.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureViewModel.swift
@@ -21,7 +21,7 @@ public final class MainFeatureViewModel: ViewModel {
         case manageMySeatButtonDidTap // 좌석 관리 버튼
         case willRegisterSeat(Seat) // 좌석 등록
         case willMoveSeat(Seat) // 좌석 이동
-        case willCancelSeat(Seat) // 좌석 취소
+        case willCancelSeat(Seat?) // 좌석 취소
         case backToSeatSectionPage // 좌석 구역 페이지로 이동
         case manageSeatSection(SeatSectionAction) // 좌석 관리 액션 수행
         case manageSeatRequest(SeatRequestAction) // 좌석 요청 관련 액션 수행
@@ -471,7 +471,7 @@ public final class MainFeatureViewModel: ViewModel {
     }
     
     @MainActor
-    private func cancelSeat(_ seat: Seat) {
+    private func cancelSeat(_ seat: Seat?) {
         /// 좌석 정보를 취소합니다
         if let cancelSeatUseCase {
             Task {

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/SelectPath/InputCarCode/InputCarCodeViewModel.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/SelectPath/InputCarCode/InputCarCodeViewModel.swift
@@ -73,6 +73,7 @@ public final class InputCarCodeViewModel: ViewModel {
                         expectedArrivalTime: expectedArrivalTime,
                         arrivalTimePublisher: arrivalTimePublisher
                     )
+                    coordinator.popToRoot()
                     coordinator.push(AppScene.selectSeatSection)
                 }
             }

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/SelectSeatSection/SelectSeatSectionViewModel.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/SelectSeatSection/SelectSeatSectionViewModel.swift
@@ -62,14 +62,15 @@ public final class SelectSeatSectionViewModel: ViewModel {
                     trainCode: trainCode,
                     carCode: carCode
                 )
-                // occupant가 있는 section만 포함
-                let availableSections = trainCar.seatInfo.compactMap { (sectionType, seatSection) -> SeatSectionType? in
-                    let hasAvailableSeat = seatSection.topSeats.values.contains { $0.occupant != nil } ||
-                    seatSection.bottomSeats.values.contains { $0.occupant != nil }
-                    return hasAvailableSeat ? sectionType : nil
-                }
-                // availableSections 업데이트
-                self.state.availableSections = availableSections
+                store.trainCar = trainCar
+//                // occupant가 있는 section만 포함
+//                let availableSections = trainCar.seatInfo.compactMap { (sectionType, seatSection) -> SeatSectionType? in
+//                    let hasAvailableSeat = seatSection.topSeats.values.contains { $0.occupant != nil } ||
+//                    seatSection.bottomSeats.values.contains { $0.occupant != nil }
+//                    return hasAvailableSeat ? sectionType : nil
+//                }
+//                // availableSections 업데이트
+//                self.state.availableSections = availableSections
             }
         case let .willSelectOption(option):
             if option == self.state.selectedOption {

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/SelectSeatSection/SelectSeatSectionViewModel.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/SelectSeatSection/SelectSeatSectionViewModel.swift
@@ -63,14 +63,14 @@ public final class SelectSeatSectionViewModel: ViewModel {
                     carCode: carCode
                 )
                 store.trainCar = trainCar
-//                // occupant가 있는 section만 포함
-//                let availableSections = trainCar.seatInfo.compactMap { (sectionType, seatSection) -> SeatSectionType? in
-//                    let hasAvailableSeat = seatSection.topSeats.values.contains { $0.occupant != nil } ||
-//                    seatSection.bottomSeats.values.contains { $0.occupant != nil }
-//                    return hasAvailableSeat ? sectionType : nil
-//                }
-//                // availableSections 업데이트
-//                self.state.availableSections = availableSections
+                // occupant가 있는 section만 포함
+                let availableSections = trainCar.seatInfo.compactMap { (sectionType, seatSection) -> SeatSectionType? in
+                    let hasAvailableSeat = seatSection.topSeats.values.contains { $0.occupant != nil } ||
+                    seatSection.bottomSeats.values.contains { $0.occupant != nil }
+                    return hasAvailableSeat ? sectionType : nil
+                }
+                // availableSections 업데이트
+                self.state.availableSections = availableSections
             }
         case let .willSelectOption(option):
             if option == self.state.selectedOption {

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/Onboarding/UserGreetingViewModel.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/Onboarding/UserGreetingViewModel.swift
@@ -48,6 +48,7 @@ public final class UserGreetingViewModel: ViewModel {
                 try? await Task.sleep(for: .seconds(1))
 
                 self.action(.fadedOut)
+                appStore.setUser(user)
             }
         case .fadedOut:
             // AppStore에 User 정보 전달 -> user.hasOnBoarded가 true로 전환되며 메인 플로우 시작

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/Onboarding/UserInfoViewModel.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/Onboarding/UserInfoViewModel.swift
@@ -88,7 +88,6 @@ public final class UserInfoViewModel: ViewModel {
                 var requestUser = appStore.user
                 requestUser.hasOnBoarded = true
                 let user = try await patchUserInfoUseCase.execute(requestUser)
-                appStore.setUser(user)
                 coordinator.push(OnboardingScene.userGreeting(user))
             } catch {
                 self.action(.errorOccured(error.localizedDescription))

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Helper/Seat+.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Helper/Seat+.swift
@@ -14,6 +14,19 @@ extension Seat {
         // 좌석 방향
         let directionPrefix = seatDirection == .top ? "seat_top" : "seat_bottom"
         
+        // 내가 앉아있는 자리
+        if isMySeat {
+            if isSelecting {
+                if isSelected { // 선택 중
+                    return ImageResource(name: "\(directionPrefix)_user", bundle: .module) // 내가 앉아있는 자리 선택중
+                } else {
+                    return ImageResource(name: "\(directionPrefix)_empty", bundle: .module) // 내가 앉아있는 자리 미선택
+                }
+            } else {
+                return ImageResource(name: "\(directionPrefix)_user", bundle: .module) // 선택 중 아닐 때
+            }
+        }
+        
         // 잠금
         if isBlocked {
             return ImageResource(name: "\(directionPrefix)_blocked", bundle: .module)
@@ -27,11 +40,6 @@ extension Seat {
             } else {
                 return ImageResource(name: "\(directionPrefix)_empty", bundle: .module)
             }
-        }
-        
-        // 내가 앉아있는 자리
-        if isMySeat {
-            return ImageResource(name: "\(directionPrefix)_user", bundle: .module)
         }
         
         // 빈 자리

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Route/AppRoute.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Route/AppRoute.swift
@@ -145,11 +145,7 @@ public enum AppSheet: AppRoute {
         confirmationButtonAction: () -> Void
     )
     case seatInfo(
-        name: String,
-        userImage: UserImage,
-        tags: [UserTag],
-        arrivalStationName: String,
-        expectedArrivalTime: Date,
+        occupant: Occupant,
         reportButtonAction: () -> Void,
         yieldButtonAction: () -> Void
     )


### PR DESCRIPTION
## ✅ Description
- 메인피처 플로우 연동입니다

## ⭐️ PR Point
<!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
- SeatInfoBottomSeatView 연동했습니다.

## 💡 Issue
- Resolved: #60 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 좌석 정보 하단 시트에서 신고 버튼을 통한 신고 및 확인 알림이 추가되었습니다.

- **버그 수정**
  - 좌석 선택 및 등록, 이동, 취소 후 홈 화면으로 자동 이동되도록 개선되었습니다.

- **리팩터**
  - 좌석 정보 시트 및 관련 화면에서 탑승자 정보를 하나의 객체로 통합하여 관리합니다.
  - 좌석 및 탑승자 객체의 동등성 비교 로직이 개선되었습니다.
  - 내비게이션 스택에서 여러 단계 한 번에 뒤로 가기 기능이 추가되었습니다.

- **스타일/UX**
  - 좌석 정보 시트의 버튼명이 "확인"으로 임시 변경되었습니다.
  - 신고 접수 시 확인 알림이 표시됩니다.

- **기타**
  - 디버깅을 위한 데이터 출력이 여러 네트워크 및 저장소 로직에 추가되었습니다.
  - 앱이 비암호화 기술을 사용하지 않음을 명시적으로 선언했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->