### PR TITLE
[#68] 착석 정보 DTO 매핑 로직 수정

### DIFF
--- a/SeatCatcherData/Sources/SeatCatcherData/DTOs/Trains/GetSeatInTrainCarResponseDTO.swift
+++ b/SeatCatcherData/Sources/SeatCatcherData/DTOs/Trains/GetSeatInTrainCarResponseDTO.swift
@@ -195,7 +195,7 @@ extension OccupantInfo {
             profileImage: UserImage(rawValue: profileImageNum) ?? .catchy1,
             tags: tags.compactMap { UserTag(rawValue: $0) },
             minutesLeftToGetOff: expectedArrivalTime.minutesUntilDropOff() ?? 0,
-            stationToGetOff: getOffStationName ?? "알 수 없음"
+            stationToGetOff: getOffStationName
         )
     }
 }

--- a/SeatCatcherData/Sources/SeatCatcherData/DTOs/Trains/GetSeatInTrainCarResponseDTO.swift
+++ b/SeatCatcherData/Sources/SeatCatcherData/DTOs/Trains/GetSeatInTrainCarResponseDTO.swift
@@ -24,18 +24,18 @@ struct SeatInfo: Codable {
 struct OccupantInfo: Codable {
     let userId: Int
     let nickname: String
-    let getOffRemainingCount: Int?
-    let profileImageNum: String // FIXME: 서버 작업 중
-    let getOffStation: String? // FIXME: 서버 작업 중
-    let tags: [String] // FIXME: 서버 작업 중
+    let expectedArrivalTime: String
+    let profileImageNum: String
+    let getOffStationName: String
+    let tags: [String]
     
     static var stub: Self {
         .init(
-            userId: 1,
-            nickname: "신기한 발바닥",
-            getOffRemainingCount: 33,
-            profileImageNum: "IMAGE_1",
-            getOffStation: "상도역",
+            userId: 2,
+            nickname: "뜨거운 승강장",
+            expectedArrivalTime: "2025-06-11T15:50:13.84318",
+            profileImageNum: "IMAGE_2",
+            getOffStationName: "서울대입구",
             tags: ["USERTAG_LONGDISTANCE", "USERTAG_CARRIER"]
         )
     }
@@ -194,8 +194,8 @@ extension OccupantInfo {
             name: nickname,
             profileImage: UserImage(rawValue: profileImageNum) ?? .catchy1,
             tags: tags.compactMap { UserTag(rawValue: $0) },
-            minutesLeftToGetOff: getOffRemainingCount ?? 0,
-            stationToGetOff: getOffStation ?? ""
+            minutesLeftToGetOff: expectedArrivalTime.minutesUntilDropOff() ?? 0,
+            stationToGetOff: getOffStationName ?? "알 수 없음"
         )
     }
 }
@@ -238,5 +238,24 @@ fileprivate extension SeatType {
         case "PRIORITY": self = .priority
         default: throw SeatCatcherDataError.InvalidSeatType
         }
+    }
+}
+
+// 잔여 시간 계산
+fileprivate extension String {
+    func minutesUntilDropOff() -> Int? {
+        let formatter = ISO8601DateFormatter() // UTC 기본
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        
+        guard let dropOffDate = formatter.date(from: self) else {
+            return nil
+        }
+        
+        let currentDate = Date() // UTC 기준
+        
+        let seconds = dropOffDate.timeIntervalSince(currentDate)
+        
+        // 초를 분으로 변환 (올림 처리)
+        return seconds > 0 ? Int(ceil(seconds / 60.0)) : 0
     }
 }

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/BottomSheet/New/SeatInfoBottomSheetView.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/BottomSheet/New/SeatInfoBottomSheetView.swift
@@ -14,11 +14,6 @@ public struct SeatInfoBottomSheetView: View {
     let reportButtonAction: () -> Void
     let yieldButtonAction: () -> Void
 
-    // FIXME: - 실제 하차역으로 교체 서버에서 안옴
-    let dummyDest = ["건대입구", "대림"].randomElement()!
-    // FIXME: - 실제 하차역으로 교체 서버에서 안옴
-    let dummyTime = (3...45).randomElement()!
-
     public init(
         occupant: Occupant,
         reportButtonAction: @escaping () -> Void,
@@ -76,11 +71,8 @@ public struct SeatInfoBottomSheetView: View {
 
                 VStack(alignment: .leading, spacing: 12) {
                     Group {
-                        // FIXME: - 실제 하차역으로 교체 서버에서 안옴
-                        Text("\(dummyDest)역")
-                        // FIXME: - 실제 남은시간으로 교체 서버에서 안옴
-                        Text("\(dummyTime)분 남았어요")
-//                        Text("\(occupant.minutesLeftToGetOff)분 남았어요")
+                        Text("\(occupant.stationToGetOff)역")
+                        Text("\(occupant.minutesLeftToGetOff)분 남았어요")
                     }
                     .font(.B02_M)
                     .foregroundStyle(.gray100)


### PR DESCRIPTION
## ✅ Description
- `expectedArrivalTime` Timezone 관련
  - `Date()`도 UTC 기준이고 서버에서도 UTC 기준이라 시간 텀 계산에는 KST 변환이 필요없어서 그대로 계산했습니다~
- 바텀시트에도 반영했습니다~

## ⭐️ PR Point
<!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
-

## 📸 Simulator


## 💡 Issue
- Resolved: #68 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 승객 정보에 도착 예정 시간과 하차역 이름이 표시됩니다.
  - 남은 시간과 하차역이 실제 데이터로 UI에 표시됩니다.

- **스타일**
  - 더미 데이터가 제거되고 실제 승객 정보가 반영되어 화면이 더욱 정확하게 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->