### PR TITLE
[#70] 메인피쳐 플로우 보완 및 메인피쳐 잠금 해제 - 완료 뷰 구현

### DIFF
--- a/SeatCatcher/SeatCatcher/Sources/App/Coordinator/AppCoordinator.swift
+++ b/SeatCatcher/SeatCatcher/Sources/App/Coordinator/AppCoordinator.swift
@@ -172,6 +172,12 @@ final class AppCoordinator: Coordinator {
                 unlockSeatUseCase: diContainer.resolveUnlockSeatUseCase()
             )
             UnlockSeatGuideView(viewModel: viewModel)
+        case let .mainFeatureActionComplete(actionCase):
+            let viewModel = MainFeatureActionCompleteViewModel(
+                coordinator: self,
+                actionCase: actionCase
+            )
+            MainFeatureActionCompleteView(viewModel: viewModel)
         }
     }
 

--- a/SeatCatcher/SeatCatcher/Sources/App/Coordinator/AppCoordinator.swift
+++ b/SeatCatcher/SeatCatcher/Sources/App/Coordinator/AppCoordinator.swift
@@ -117,7 +117,6 @@ final class AppCoordinator: Coordinator {
                 coordinator: self,
                 getSeatInTrainCarUseCase: diContainer.resolveGetSeatInTrainCarUseCase(),
                 getSeatInSectionUseCase: diContainer.resolveGetSeatInSectionUseCase(),
-                unlockSeatUseCase: diContainer.resolveUnlockSeatUseCase(),
                 subscribeTrainUseCase: diContainer.resolveSubscribeTrainUseCase(),
                 postSeatRequestUseCase: diContainer.resolveRequestSeatUseCase(),
                 cancelSeatRequestUseCase: diContainer.resolveCancelRequestSeatUseCase(),
@@ -131,7 +130,6 @@ final class AppCoordinator: Coordinator {
                 coordinator: self,
                 getSeatInTrainCarUseCase: diContainer.resolveGetSeatInTrainCarUseCase(),
                 getSeatInSectionUseCase: diContainer.resolveGetSeatInSectionUseCase(),
-                unlockSeatUseCase: diContainer.resolveUnlockSeatUseCase(),
                 registerSeatUseCase: diContainer.resolveRegisterSeatUseCase()
             )
             MainFeatureView(viewModel: viewModel)
@@ -141,7 +139,6 @@ final class AppCoordinator: Coordinator {
                 coordinator: self,
                 getSeatInTrainCarUseCase: diContainer.resolveGetSeatInTrainCarUseCase(),
                 getSeatInSectionUseCase: diContainer.resolveGetSeatInSectionUseCase(),
-                unlockSeatUseCase: diContainer.resolveUnlockSeatUseCase(),
                 moveSeatUseCase: diContainer.resolveMoveSeatUseCase()
             )
             MainFeatureView(viewModel: viewModel)
@@ -151,7 +148,6 @@ final class AppCoordinator: Coordinator {
                 coordinator: self,
                 getSeatInTrainCarUseCase: diContainer.resolveGetSeatInTrainCarUseCase(),
                 getSeatInSectionUseCase: diContainer.resolveGetSeatInSectionUseCase(),
-                unlockSeatUseCase: diContainer.resolveUnlockSeatUseCase(),
                 cancelSeatUseCase: diContainer.resolveCancelSeatUseCase()
             )
             MainFeatureView(viewModel: viewModel)
@@ -169,6 +165,13 @@ final class AppCoordinator: Coordinator {
                 getSeatInTrainCarUseCase: diContainer.resolveGetSeatInTrainCarUseCase()
             )
             SelectSeatSectionView(viewModel: viewModel)
+        case .unlockSeatGuide:
+            let viewModel = UnlockSeatGuideViewModel(
+                store: diContainer.resolveAppStore(),
+                coordinator: self,
+                unlockSeatUseCase: diContainer.resolveUnlockSeatUseCase()
+            )
+            UnlockSeatGuideView(viewModel: viewModel)
         }
     }
 

--- a/SeatCatcherData/Sources/SeatCatcherData/DTOs/User/PatchCreditRequestDTO.swift
+++ b/SeatCatcherData/Sources/SeatCatcherData/DTOs/User/PatchCreditRequestDTO.swift
@@ -1,0 +1,13 @@
+//
+//  PatchCreditRequestDTO.swift
+//  SeatCatcherData
+//
+//  Created by 황채웅 on 6/12/25.
+//
+
+import Foundation
+
+struct PatchCreditRequestDTO: RequestDTO {
+    let amount: Int
+    let targetUserId: Int
+}

--- a/SeatCatcherData/Sources/SeatCatcherData/Network/Moya/SeatCatcherAPI.swift
+++ b/SeatCatcherData/Sources/SeatCatcherData/Network/Moya/SeatCatcherAPI.swift
@@ -37,6 +37,8 @@ enum SeatCatcherAPI: Sendable {
     case rejectSeatRequest(seatId: Int, requesterId: Int, creditAmount: Int)
 
     case getIncomings(requestDTO: GetIncomingsRequestDTO)
+    
+    case patchCredit(requestDTO: PatchCreditRequestDTO)
 }
 
 extension SeatCatcherAPI: TargetType {
@@ -89,6 +91,8 @@ extension SeatCatcherAPI: TargetType {
             return "/user/seats/\(seatId)/yield"
         case .patchSeatOccupant:
             return "/user/seats"
+        case .patchCredit(requestDTO: let requestDTO):
+            return "/credit"
         }
     }
     
@@ -133,6 +137,8 @@ extension SeatCatcherAPI: TargetType {
         case .rejectSeatRequest:
             return .post
         case .patchSeatOccupant:
+            return .patch
+        case .patchCredit:
             return .patch
         }
     }
@@ -216,9 +222,22 @@ extension SeatCatcherAPI: TargetType {
             return .requestParameters(parameters: parameters, encoding: URLEncoding.default)
         case let .patchSeatOccupant(requestDTO):
             return .requestJSONEncodable(requestDTO)
+        case let .patchCredit(requestDTO):
+            let requestBodyParameters: [String: Any] = [
+                "amount": abs((requestDTO.amount)), // 절댓값
+                "targetUserId": requestDTO.targetUserId
+            ]
+            let queryParameter: [String: Any] = [
+                "isAddition": requestDTO.amount > 0 // 지급, 차감 여부
+            ]
+            return .requestCompositeParameters(
+                bodyParameters: requestBodyParameters,
+                bodyEncoding: JSONEncoding.default,
+                urlParameters: queryParameter
+            )
         }
     }
-
+    
     var headers: [String : String]? {
         var accessToken: String { (try? KeychainService.get(key: "accessToken")) ?? "" }
 
@@ -268,6 +287,8 @@ extension SeatCatcherAPI: TargetType {
         case .rejectSeatRequest:
             return baseWithAuth
         case .patchSeatOccupant:
+            return baseWithAuth
+        case .patchCredit:
             return baseWithAuth
         }
     }

--- a/SeatCatcherData/Sources/SeatCatcherData/Network/Moya/SeatCatcherAPI.swift
+++ b/SeatCatcherData/Sources/SeatCatcherData/Network/Moya/SeatCatcherAPI.swift
@@ -91,7 +91,7 @@ extension SeatCatcherAPI: TargetType {
             return "/user/seats/\(seatId)/yield"
         case .patchSeatOccupant:
             return "/user/seats"
-        case .patchCredit(requestDTO: let requestDTO):
+        case .patchCredit:
             return "/credit"
         }
     }

--- a/SeatCatcherData/Sources/SeatCatcherData/Repositories/Seat/SeatRepositoryImpl.swift
+++ b/SeatCatcherData/Sources/SeatCatcherData/Repositories/Seat/SeatRepositoryImpl.swift
@@ -24,7 +24,7 @@ public final class SeatRepositoryImpl: SeatRepository, Sendable {
     }
 
     public func unlockAllSeats(creditAmount: Int, targetUserId: Int) async throws {
-        try await networkService.patchCredit(creditAmount: 300, targetUserId: targetUserId)
+        try await networkService.patchCredit(creditAmount: creditAmount, targetUserId: targetUserId)
         return
     }
         

--- a/SeatCatcherData/Sources/SeatCatcherData/Repositories/Seat/SeatRepositoryImpl.swift
+++ b/SeatCatcherData/Sources/SeatCatcherData/Repositories/Seat/SeatRepositoryImpl.swift
@@ -23,8 +23,8 @@ public final class SeatRepositoryImpl: SeatRepository, Sendable {
         return response.domainModel
     }
 
-    public func unlockAllSeats() async throws {
-        // TODO: 크레딧 차감 API 호출
+    public func unlockAllSeats(creditAmount: Int, targetUserId: Int) async throws {
+        try await networkService.patchCredit(creditAmount: 300, targetUserId: targetUserId)
         return
     }
         

--- a/SeatCatcherData/Sources/SeatCatcherData/Services/NetworkService.swift
+++ b/SeatCatcherData/Sources/SeatCatcherData/Services/NetworkService.swift
@@ -265,4 +265,9 @@ public struct NetworkService: Sendable {
         let responseDTO = try JSONDecoder().decode([GetIncomingsResponseDTO].self, from: response)
         return responseDTO
     }
+    
+    // MARK: - Credit
+    func patchCredit(creditAmount: Int, targetUserId: Int) async throws {
+        try await provider.request(.patchCredit(requestDTO: PatchCreditRequestDTO(amount: creditAmount, targetUserId: targetUserId)))
+    }
 }

--- a/SeatCatcherDomain/Sources/SeatCatcherDomain/Repositories/Seat/SeatRepository.swift
+++ b/SeatCatcherDomain/Sources/SeatCatcherDomain/Repositories/Seat/SeatRepository.swift
@@ -12,7 +12,7 @@ public protocol SeatRepository: Sendable {
     func getSeatsInTrainCar(trainCode: String, carCode: String) async throws -> TrainCar
     // MARK: - 좌석 상태 관리
     /// 좌석 정보 잠금을 해제합니다
-    func unlockAllSeats() async throws
+    func unlockAllSeats(creditAmount: Int, targetUserId: Int) async throws
     /// 좌석 정보를 등록합니다
     func registerSeat(_ seat: Seat) async throws
     /// 좌석 정보를 취소합니다

--- a/SeatCatcherDomain/Sources/SeatCatcherDomain/UseCases/Seat/UnlockSeatUseCase.swift
+++ b/SeatCatcherDomain/Sources/SeatCatcherDomain/UseCases/Seat/UnlockSeatUseCase.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public protocol UnlockSeatUseCase: Sendable {
-    func execute() async throws
+    func execute(creditAmount: Int, targetUserId: Int) async throws
 }
 
 public final class UnlockSeatUseCaseImpl: UnlockSeatUseCase {
@@ -19,7 +19,7 @@ public final class UnlockSeatUseCaseImpl: UnlockSeatUseCase {
         self.seatRepository = seatRepository
     }
     
-    public func execute() async throws {
-        try await seatRepository.unlockAllSeats()
+    public func execute(creditAmount: Int, targetUserId: Int) async throws {
+        try await seatRepository.unlockAllSeats(creditAmount: creditAmount, targetUserId: targetUserId)
     }
 }

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Common/Components/SeatSectionView.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Common/Components/SeatSectionView.swift
@@ -65,7 +65,7 @@ private struct SeatRowView: View {
                 if shouldShowSeat(seat: seat) {
                     Image(seat.image(
                         isSelected: selectedSeat?.id == seat.id,
-                        isBlocked: isBlocked && seat.occupant != nil,
+                        isBlocked: isBlocked && seat.occupant != nil && seat.id != mySeat?.id,
                         isSelecting: userStatus == .registering || userStatus == .moving,
                         isMySeat: mySeat?.id == seat.id
                     )

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/Home/HomeViewModel.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/Home/HomeViewModel.swift
@@ -98,6 +98,7 @@ public final class HomeViewModel: ViewModel {
             }
         case .quickBoardingButtonTapped:
             if store.isOnJourney {
+                coordinator.push(AppScene.selectSeatSection)
                 coordinator.push(AppScene.mainFeature)
             } else {
                 Task { [getStationUseCase] in

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureActionComplete/MainFeatureActionCompleteView.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureActionComplete/MainFeatureActionCompleteView.swift
@@ -1,0 +1,64 @@
+//
+//  MainFeatureActionCompleteView.swift
+//  SeatCatcherPresentation
+//
+//  Created by 황채웅 on 6/12/25.
+//
+
+import SwiftUI
+
+public struct MainFeatureActionCompleteView: View {
+    
+    @State var viewModel: MainFeatureActionCompleteViewModel
+    
+    public init(viewModel: MainFeatureActionCompleteViewModel) {
+        self._viewModel = State(initialValue: viewModel)
+    }
+    
+    public var body: some View {
+        
+        let config = viewModel.state.actionCase.config
+        
+        VStack(alignment: .center) {
+            Image(config.iconImage)
+                .resizable()
+                .frame(width: 80, height: 80)
+                .padding(.top, 221)
+                .padding(.bottom, 20)
+            Text(config.title)
+                .multilineTextAlignment(.center)
+                .font(.T01_SB)
+                .foregroundStyle(.gray100)
+                .padding(.top, 20)
+            Text(config.subtitle)
+                .multilineTextAlignment(.center)
+                .underline(config.hasUnderline)
+                .font(.B03_M)
+                .foregroundStyle(.gray300)
+                .padding(.top, 20)
+            Spacer(minLength: 0)
+            if let buttonTitle = config.buttonTitle {
+                CTAButton(
+                    title: buttonTitle,
+                    action: {
+                        viewModel.action(.willDismiss) // 버튼이 있는 경우 버튼 터치 시 dismiss
+                    },
+                    style:
+                        buttonTitle == "확인"
+                    ? .bottomEnabled // 확인
+                    : .bottomMain // 요청 취소하기
+                )
+                .padding(.horizontal, 18)
+                .padding(.bottom, 2)
+            }
+        }
+        .applyToolbarVisibility(.hidden, for: .navigationBar)
+        .ignoresSafeArea()
+        .withBackground(.gray900)
+        .onTapGesture {
+            if config.buttonTitle == nil {
+                viewModel.action(.willDismiss) // 버튼이 없는 경우 터치 시 dismiss
+            }
+        }
+    }
+}

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureActionComplete/MainFeatureActionCompleteView.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureActionComplete/MainFeatureActionCompleteView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 public struct MainFeatureActionCompleteView: View {
     
-    @State var viewModel: MainFeatureActionCompleteViewModel
+    @State private var viewModel: MainFeatureActionCompleteViewModel
     
     public init(viewModel: MainFeatureActionCompleteViewModel) {
         self._viewModel = State(initialValue: viewModel)

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureActionComplete/MainFeatureActionCompleteViewModel.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureActionComplete/MainFeatureActionCompleteViewModel.swift
@@ -1,0 +1,134 @@
+//
+//  MainFeatureActionCompleteViewModel.swift
+//  SeatCatcherPresentation
+//
+//  Created by 황채웅 on 6/12/25.
+//
+
+import Foundation
+import SwiftUI
+import SeatCatcherCore
+import SeatCatcherDomain
+
+@Observable
+public final class MainFeatureActionCompleteViewModel: ViewModel {
+    struct State {
+        var actionCase: MainFeatureActionCase
+    }
+    
+    struct Config {
+        let iconImage: ImageResource
+        let title: String
+        let subtitle: String
+        let hasUnderline: Bool
+        let buttonTitle: String?
+    }
+    
+    public enum MainFeatureActionCase: Equatable {
+        case unlockedSeat(creditAmount: Int) // 좌석 정보 잠금 해제
+        case requestInProcess(stationName: String) // 요청 중
+        case requestAccepted(stationName: String) // 좌석 요청이 수락됨
+        case requestRejected // 좌석 요청이 거절됨
+        case sendCredit(creditAmount: Int) // 좌석을 양보 받은 후 크레딧 전달
+        case receivedCreditByYield(creditAmount: Int) // 좌석 양보로 크레딧 지급
+        case receivedCreditByRegister(creditAmount: Int) // 좌석 정보 입력 크레딧 지급
+        case takeBackCreditByCancel(creditAmount: Int) // 좌석 정보 입력 크레딧 회수
+        
+        var config: Config {
+            switch self {
+            case .unlockedSeat(let creditAmount):
+                return Config(
+                    iconImage: .iconSeat,
+                    title: "좌석정보\n획득 완료!",
+                    subtitle: "\(creditAmount) 크레딧이 차감되었어요.",
+                    hasUnderline: false,
+                    buttonTitle: nil
+                )
+            case .requestInProcess(let stationName):
+                return Config(
+                    iconImage: .dangerCircle,
+                    title: "요청 중",
+                    subtitle: "\(stationName)역을 지난 뒤부터\n좌석을 바꿀 수 있어요",
+                    hasUnderline: false,
+                    buttonTitle: "요청 취소하기"
+                )
+            case .requestAccepted(let stationName):
+                return Config(
+                    iconImage: .iconAccept,
+                    title: "요청이 수락됐어요",
+                    subtitle: "\(stationName)역을 지난 뒤부터\n좌석을 바꿀 수 있어요",
+                    hasUnderline: false,
+                    buttonTitle: "확인"
+                )
+            case .requestRejected:
+                return Config(
+                    iconImage: .iconReject,
+                    title: "요청이 거절됐어요",
+                    subtitle: "수락 여부와 관계없이\n크레딧은 소모됩니다.",
+                    hasUnderline: true,
+                    buttonTitle: "확인"
+                )
+            case .sendCredit(let creditAmount):
+                return Config(
+                    iconImage: .iconSeat,
+                    title: "\(creditAmount) 크레딧을 전달했어요",
+                    subtitle: "편안하고 쾌적한 이동 되세요!",
+                    hasUnderline: false,
+                    buttonTitle: nil
+                )
+            case .receivedCreditByYield(let creditAmount):
+                return Config(
+                    iconImage: .iconCreditPlus,
+                    title: "\(creditAmount) 크레딧을\n받았어요",
+                    subtitle: "크레딧스토어에서 받은 크레딧을 확인해보세요!",
+                    hasUnderline: false,
+                    buttonTitle: nil
+                )
+            case .receivedCreditByRegister(let creditAmount):
+                return Config(
+                    iconImage: .iconCreditPlus,
+                    title: "\(creditAmount) 크레딧을\n받았어요",
+                    subtitle: "크레딧스토어에서 받은 크레딧을 확인해보세요!",
+                    hasUnderline: false,
+                    buttonTitle: nil
+                )
+            case .takeBackCreditByCancel(let creditAmount):
+                return Config(
+                    iconImage: .iconCreditMinus,
+                    title: "\(creditAmount) 크레딧이\n회수됐어요",
+                    subtitle: "등록 후, 5분 내 취소 시 리워드는 회수됩니다.",
+                    hasUnderline: true,
+                    buttonTitle: nil
+                )
+            }
+        }
+    }
+    
+    enum Action {
+        case willDismiss
+    }
+    
+    private let coordinator: Coordinator
+    
+    private(set) var state: State
+    
+    @MainActor
+    public init(coordinator: Coordinator, actionCase: MainFeatureActionCase) {
+        self.coordinator = coordinator
+        self.state = .init(actionCase: actionCase)
+    }
+    
+    func action(_ action: Action) {
+        switch action {
+        case .willDismiss:
+            switch state.actionCase {
+            case .sendCredit, .receivedCreditByYield:
+                coordinator.popLast(1) // FIXME: 코디네이터 애니메이션 필요
+            case .unlockedSeat, .requestInProcess:
+                coordinator.popLast(2) // FIXME: 코디네이터 애니메이션 필요
+            case .requestAccepted, .requestRejected, .takeBackCreditByCancel,.receivedCreditByRegister:
+                coordinator.popLast(3) // FIXME: 코디네이터 애니메이션 필요
+            }
+        }
+    }
+}

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureView.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureView.swift
@@ -18,14 +18,14 @@ public struct MainFeatureView: View {
     
     public var body: some View {
         VStack(spacing: 0) {
-            TitleTextView(seatSection: viewModel.state.seatSectionType, status: viewModel.state.userStatus)
+            TitleTextView(seatSection: viewModel.state.seatSectionType, status: viewModel.state.userStatus, isBlocked: viewModel.store.isBlocked)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.top, 18)
                 .padding(.bottom, 32)
             SeatSectionView(
                 selectedSeat: viewModel.state.seatSectionState.selectedSeat,
                 isBlocked: viewModel.state.seatSectionState.isBlocked,
-                mySeat: viewModel.state.seatSectionState.mySeat,
+                mySeat: viewModel.state.mySeat,
                 seats: viewModel.state.seatSectionState.seats,
                 userStatus: viewModel.state.userStatus,
                 onTap: { seat in
@@ -77,18 +77,19 @@ public struct MainFeatureView: View {
 private struct TitleTextView: View {
     let seatSection: SeatSectionType
     let status: MainFeatureViewModel.UserStatus
+    let isBlocked: Bool
     
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text(
-                MainFeatureLiterals.getTitleText(seatSection: seatSection, status: status).title,
+                MainFeatureLiterals.getTitleText(seatSection: seatSection, status: status, isBlocked: isBlocked).title,
                 styledSubstring: seatSection.rawValue,
                 color: .scGreen,
                 font: .T02_B
             )
             .font(.T02_B)
             .foregroundStyle(.gray100)
-            if let subtitle = MainFeatureLiterals.getTitleText(seatSection: seatSection, status: status).subtitle {
+            if let subtitle = MainFeatureLiterals.getTitleText(seatSection: seatSection, status: status, isBlocked: isBlocked).subtitle {
                 Text(subtitle)
                     .font(.B03_M)
                     .foregroundStyle(.gray300)
@@ -187,7 +188,7 @@ private struct CTAButtonView: View {
                         viewModel.action(.willMoveSeat(seat))
                     }
                 case .cancelling:    
-                    viewModel.action(.willCancelSeat(viewModel.state.seatSectionState.mySeat))
+                    viewModel.action(.willCancelSeat(viewModel.state.mySeat))
                 }
             },
             style: ctaButtonStyle

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureViewModel.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureViewModel.swift
@@ -344,7 +344,6 @@ public final class MainFeatureViewModel: ViewModel {
         }
     }
     
-    
     /// 구독 해제
     @MainActor
     private func unsubscribeFromTrain() { // TODO: - 백그라운드에서도 연결 유지해야하므로 추후 검토 후 삭제
@@ -356,7 +355,6 @@ public final class MainFeatureViewModel: ViewModel {
     
     @MainActor
     private func handleSeatSectionAction(_ action: SeatSectionAction) {
-        dump(state.userStatus)
         switch action {
         case .willSelectSeat(let seat):
             switch state.userStatus {
@@ -391,8 +389,8 @@ public final class MainFeatureViewModel: ViewModel {
             /// 좌석 정보를 잠금 해제합니다
             Task {
                 do {
-                    try await unlockSeatUseCase.execute()
-                    state.seatSectionState.isBlocked = false
+                    try await unlockSeatUseCase.execute(creditAmount: 300, targetUserId: store.user.id)
+                    store.isBlocked = false
                 } catch {
                     print(error.localizedDescription)
                 }

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureViewModel.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureViewModel.swift
@@ -31,7 +31,6 @@ public final class MainFeatureViewModel: ViewModel {
     
     enum SeatSectionAction {
         case willSelectSeat(Seat) // 좌석 선택
-        case willUnlockAllSeats // 좌석 정보 잠금 해제
     }
     
     enum SeatRequestAction {
@@ -50,6 +49,7 @@ public final class MainFeatureViewModel: ViewModel {
         var seatSectionType: SeatSectionType // 현재 보고있는 구역
         var lookingCount: Int // 현재 열차 내 자리를 찾는 사용자 수, 0의 경우 띄우지 않음
         var seatSectionState: SeatSectionState
+        var mySeat: Seat? // 내가 앉은 좌석
         var seatRequestState: SeatRequestState
         var isSeatFetched = false
         var isReportAlertPresented = false // 신고 alert
@@ -57,7 +57,6 @@ public final class MainFeatureViewModel: ViewModel {
     
     struct SeatSectionState {
         var selectedSeat: Seat? // 선택한 좌석
-        var mySeat: Seat? // 내가 앉은 좌석
         var isBlocked: Bool // 좌석 정보 잠금 상태
         var seats: SeatSection // 좌석 정보
     }
@@ -73,11 +72,7 @@ public final class MainFeatureViewModel: ViewModel {
     // MARK: Dependencies
     let store: AppStore
     let coordinator: Coordinator
-
-
-
-
-
+    
     // MARK: States
     private(set) var state: State
     
@@ -85,7 +80,6 @@ public final class MainFeatureViewModel: ViewModel {
     /// 필수 유즈케이스
     private let getSeatInTrainCarUseCase: GetSeatInTrainCarUseCase
     private let getSeatInSectionUseCase: GetSeatInSectionUseCase
-    private let unlockSeatUseCase: UnlockSeatUseCase
     /// 옵셔널 유즈케이스 - 좌석 등록 시
     private let registerSeatUseCase: RegisterSeatUseCase?
     /// 옵셔널 유즈케이스 - 좌석 이동 시
@@ -99,7 +93,7 @@ public final class MainFeatureViewModel: ViewModel {
     private let cancelSeatRequestUseCase : CancelRequestSeatUseCase?
     /// 옵셔널 유즈케이스 - 좌석 점유자
     private let acceptSeatRequestUseCase : AcceptRequestSeatUseCase?
-    private let rejectSeatRequestUseCase : RejectRequestSeatUseCase?    
+    private let rejectSeatRequestUseCase : RejectRequestSeatUseCase?
     
     // MARK: Initialize
     @MainActor
@@ -108,7 +102,6 @@ public final class MainFeatureViewModel: ViewModel {
         coordinator: Coordinator,
         getSeatInTrainCarUseCase: GetSeatInTrainCarUseCase,
         getSeatInSectionUseCase: GetSeatInSectionUseCase,
-        unlockSeatUseCase: UnlockSeatUseCase,
         subscribeTrainUseCase: SubscribeTrainUseCase? = nil,
         registerSeatUseCase: RegisterSeatUseCase? = nil,
         moveSeatUseCase: MoveSeatUseCase? = nil,
@@ -123,7 +116,6 @@ public final class MainFeatureViewModel: ViewModel {
         self.coordinator = coordinator
         self.getSeatInTrainCarUseCase = getSeatInTrainCarUseCase
         self.getSeatInSectionUseCase = getSeatInSectionUseCase
-        self.unlockSeatUseCase = unlockSeatUseCase
         self.subscribeTrainUseCase = subscribeTrainUseCase
         self.registerSeatUseCase = registerSeatUseCase
         self.moveSeatUseCase = moveSeatUseCase
@@ -159,7 +151,7 @@ public final class MainFeatureViewModel: ViewModel {
         coordinator: Coordinator,
         getSeatInTrainCarUseCase: GetSeatInTrainCarUseCase,
         getSeatInSectionUseCase: GetSeatInSectionUseCase,
-        unlockSeatUseCase: UnlockSeatUseCase,
+        
         subscribeTrainUseCase: SubscribeTrainUseCase,
         postSeatRequestUseCase : RequestSeatUseCase,
         cancelSeatRequestUseCase : CancelRequestSeatUseCase,
@@ -171,7 +163,6 @@ public final class MainFeatureViewModel: ViewModel {
             coordinator: coordinator,
             getSeatInTrainCarUseCase: getSeatInTrainCarUseCase,
             getSeatInSectionUseCase: getSeatInSectionUseCase,
-            unlockSeatUseCase: unlockSeatUseCase,
             subscribeTrainUseCase: subscribeTrainUseCase,
             postSeatRequestUseCase : postSeatRequestUseCase,
             cancelSeatRequestUseCase : cancelSeatRequestUseCase,
@@ -188,7 +179,7 @@ public final class MainFeatureViewModel: ViewModel {
         coordinator: Coordinator,
         getSeatInTrainCarUseCase: GetSeatInTrainCarUseCase,
         getSeatInSectionUseCase: GetSeatInSectionUseCase,
-        unlockSeatUseCase: UnlockSeatUseCase,
+        
         registerSeatUseCase: RegisterSeatUseCase
     ) {
         self.init(
@@ -196,7 +187,6 @@ public final class MainFeatureViewModel: ViewModel {
             coordinator: coordinator,
             getSeatInTrainCarUseCase: getSeatInTrainCarUseCase,
             getSeatInSectionUseCase: getSeatInSectionUseCase,
-            unlockSeatUseCase: unlockSeatUseCase,
             registerSeatUseCase: registerSeatUseCase,
             userStatus: .registering
         )
@@ -209,7 +199,6 @@ public final class MainFeatureViewModel: ViewModel {
         coordinator: Coordinator,
         getSeatInTrainCarUseCase: GetSeatInTrainCarUseCase,
         getSeatInSectionUseCase: GetSeatInSectionUseCase,
-        unlockSeatUseCase: UnlockSeatUseCase,
         moveSeatUseCase: MoveSeatUseCase
     ) {
         self.init(
@@ -217,7 +206,6 @@ public final class MainFeatureViewModel: ViewModel {
             coordinator: coordinator,
             getSeatInTrainCarUseCase: getSeatInTrainCarUseCase,
             getSeatInSectionUseCase: getSeatInSectionUseCase,
-            unlockSeatUseCase: unlockSeatUseCase,
             moveSeatUseCase: moveSeatUseCase,
             userStatus: .moving
         )
@@ -230,7 +218,6 @@ public final class MainFeatureViewModel: ViewModel {
         coordinator: Coordinator,
         getSeatInTrainCarUseCase: GetSeatInTrainCarUseCase,
         getSeatInSectionUseCase: GetSeatInSectionUseCase,
-        unlockSeatUseCase: UnlockSeatUseCase,
         cancelSeatUseCase: CancelSeatUseCase
     ) {
         self.init(
@@ -238,7 +225,6 @@ public final class MainFeatureViewModel: ViewModel {
             coordinator: coordinator,
             getSeatInTrainCarUseCase: getSeatInTrainCarUseCase,
             getSeatInSectionUseCase: getSeatInSectionUseCase,
-            unlockSeatUseCase: unlockSeatUseCase,
             cancelSeatUseCase: cancelSeatUseCase,
             userStatus: .cancelling
         )
@@ -303,7 +289,18 @@ public final class MainFeatureViewModel: ViewModel {
                     seatSectionType: state.seatSectionType
                 )
                 /// UI에 표시하기 위해 나의 좌석을 찾습니다
-                state.seatSectionState.mySeat = findMySeat()
+                if let mySeat = findMySeat(in: trainCar) {
+                    state.mySeat = mySeat
+                    if state.userStatus == .standing {
+                        state.userStatus = .seated
+                        store.isSitting = true
+                    }
+                } else {
+                    state.mySeat = nil
+                    state.userStatus = .standing
+                    store.isSitting = false
+                }
+
             }
             .store(in: &cancellables)
         /// 좌석 요청(자)  퍼블리셔
@@ -364,16 +361,20 @@ public final class MainFeatureViewModel: ViewModel {
                 guard let occupant = seat.occupant else { return }
                 // FIXME: - occupant 없을 시 방지
                 // FIXME: - 실제 seat의 occupant로 교체
-                coordinator.presentSheet(
-                    AppSheet.seatInfo(
-                        occupant: occupant,
-                        reportButtonAction: {
-                            self.action(.reportButtonDidTap)
-                        },
-                        // FIXME: - 양보 로직 달기
-                        yieldButtonAction: { self.coordinator.dismissSheet() }
+                if store.isBlocked && occupant.id != store.user.id {
+                    coordinator.push(AppScene.unlockSeatGuide) // 좌석 정보 잠금 해제 뷰
+                } else {
+                    coordinator.presentSheet( // 좌석 정보 조회
+                        AppSheet.seatInfo(
+                            occupant: occupant,
+                            reportButtonAction: {
+                                self.action(.reportButtonDidTap)
+                            },
+                            // FIXME: - 양보 로직 달기
+                            yieldButtonAction: { self.coordinator.dismissSheet() }
+                        )
                     )
-                )
+                }
             case .registering, .moving, .cancelling:
                 // 좌석을 선택합니다
                 if state.userStatus != .cancelling { // 좌석 취소 중에는 선택 불가
@@ -382,17 +383,6 @@ public final class MainFeatureViewModel: ViewModel {
                     } else {
                         state.seatSectionState.selectedSeat = seat
                     }
-                }
-            }
-
-        case .willUnlockAllSeats:
-            /// 좌석 정보를 잠금 해제합니다
-            Task {
-                do {
-                    try await unlockSeatUseCase.execute(creditAmount: 300, targetUserId: store.user.id)
-                    store.isBlocked = false
-                } catch {
-                    print(error.localizedDescription)
                 }
             }
         }
@@ -411,19 +401,25 @@ public final class MainFeatureViewModel: ViewModel {
                 let trainCar = try await getSeatInTrainCarUseCase.execute(trainCode: currentTrainCode, carCode: currentCarCode)
                 await MainActor.run {
                     guard state.trainCode == currentTrainCode,
-                    state.carCode == currentCarCode else { return }
+                          state.carCode == currentCarCode else { return }
                     /// 현재 구역의 좌석 데이터만 필터링
                     state.seatSectionState.seats = getSeatInSectionUseCase.execute(trainCar: trainCar, seatSectionType: currentSeatSectionType)
-
+                    
                     /// 나의 좌석 반영
-                    state.seatSectionState.mySeat = findMySeat()
+                    if let mySeat = findMySeat(in: trainCar) {
+                        state.mySeat = mySeat
+                        if state.userStatus == .standing {
+                            state.userStatus = .seated
+                            store.isSitting = true
+                        }
+                    }
                     
                     /// 나의 좌석 선택 처리 (좌석 등록 / 이동 시)
                     if currentUserStatus == .registering || currentUserStatus == .moving {
-                        state.seatSectionState.selectedSeat = state.seatSectionState.mySeat
+                        state.seatSectionState.selectedSeat = state.mySeat
                     }
                 }
-
+                
             } catch {
                 print(error.localizedDescription)
             }
@@ -431,9 +427,10 @@ public final class MainFeatureViewModel: ViewModel {
     }
     
     @MainActor
-    private func findMySeat() -> Seat? {
-        return state.seatSectionState.seats.topSeats.values.first { $0.occupant?.id == store.user.id }
-        ?? state.seatSectionState.seats.bottomSeats.values.first { $0.occupant?.id == store.user.id }
+    private func findMySeat(in trainCar: TrainCar) -> Seat? {
+        trainCar.seatInfo.values
+            .flatMap { Array($0.topSeats.values) + Array($0.bottomSeats.values) }
+            .first { $0.occupant?.id == store.user.id }
     }
     
     @MainActor
@@ -444,27 +441,31 @@ public final class MainFeatureViewModel: ViewModel {
                 do {
                     let requesterPublisher = try await registerSeatUseCase.execute(seat)
                     self.store.subscribeToSeatRequesterPublisher(requesterPublisher, seatId: seat.id)
+                    state.userStatus = .seated // 상태 변경
+                    store.isSitting = true
                 } catch {
                     print(error.localizedDescription)
                 }
-                coordinator.popLast(2)
             }
+            coordinator.popLast(2)
         }
     }
     
     @MainActor
     private func moveSeat(_ newSeat: Seat) {
         /// 좌석 정보를 이동합니다
-        if let moveSeatUseCase, let oldSeat = self.state.seatSectionState.mySeat {
+        if let moveSeatUseCase, let oldSeat = self.state.mySeat {
             Task {
                 do {
                     let requesterPublisher = try await moveSeatUseCase.execute(from: oldSeat, to: newSeat)
                     self.store.subscribeToSeatRequesterPublisher(requesterPublisher, seatId: newSeat.id)
+                    state.userStatus = .seated // 상태 변경
+                    store.isSitting = true
                 } catch {
                     print(error.localizedDescription)
                 }
-                coordinator.popLast(2)
             }
+            coordinator.popLast(2)
         }
     }
     
@@ -475,11 +476,14 @@ public final class MainFeatureViewModel: ViewModel {
             Task {
                 do {
                     try await cancelSeatUseCase.execute(seat)
+                    state.userStatus = .standing // 상태 변경
+                    state.mySeat = nil
+                    store.isSitting = false
                 } catch {
                     print(error.localizedDescription)
                 }
-                coordinator.popLast(2)
             }
+            coordinator.popLast(2)
         }
     }
     
@@ -539,9 +543,7 @@ public final class MainFeatureViewModel: ViewModel {
             }
         }
     }
-
-
-
+    
     public enum UserStatus: Sendable {
         case seated // 착석 중
         case standing // 자리 찾는 중

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureViewModel.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/MainFeatureViewModel.swift
@@ -48,7 +48,8 @@ public final class MainFeatureViewModel: ViewModel {
         var userStatus: UserStatus // 유저의 선택 상황
         var seatSectionType: SeatSectionType // 현재 보고있는 구역
         var lookingCount: Int // 현재 열차 내 자리를 찾는 사용자 수, 0의 경우 띄우지 않음
-        var seatSectionState: SeatSectionState
+        var seatSectionState: SeatSectionState // 보고있는 구역 좌석 정보
+        var trainCar: TrainCar // 열차 전체 좌석 정보
         var mySeat: Seat? // 내가 앉은 좌석
         var seatRequestState: SeatRequestState
         var isSeatFetched = false
@@ -136,6 +137,7 @@ public final class MainFeatureViewModel: ViewModel {
                 isBlocked: store.isBlocked,
                 seats: .init(topSeats: [:], bottomSeats: [:])
             ),
+            trainCar: TrainCar(carCode: store.carCode ?? "", seatInfo: [:]),
             seatRequestState: .init(
                 requesters: [], // 초깃값
                 requestee: nil // 초깃값
@@ -179,7 +181,6 @@ public final class MainFeatureViewModel: ViewModel {
         coordinator: Coordinator,
         getSeatInTrainCarUseCase: GetSeatInTrainCarUseCase,
         getSeatInSectionUseCase: GetSeatInSectionUseCase,
-        
         registerSeatUseCase: RegisterSeatUseCase
     ) {
         self.init(
@@ -283,24 +284,15 @@ public final class MainFeatureViewModel: ViewModel {
         store.trainCarPublisher
             .sink { [weak self] trainCar in
                 guard let self, let trainCar else { return }
+                /// 전체 열차 정보를 저장합니다
+                state.trainCar = trainCar
                 /// 현재 보고 있는 구역의 좌석 정보만을 가져옵니다
                 state.seatSectionState.seats = getSeatInSectionUseCase.execute(
                     trainCar: trainCar,
                     seatSectionType: state.seatSectionType
                 )
-                /// UI에 표시하기 위해 나의 좌석을 찾습니다
-                if let mySeat = findMySeat(in: trainCar) {
-                    state.mySeat = mySeat
-                    if state.userStatus == .standing {
-                        state.userStatus = .seated
-                        store.isSitting = true
-                    }
-                } else {
-                    state.mySeat = nil
-                    state.userStatus = .standing
-                    store.isSitting = false
-                }
-
+                /// ViewModel과 AppStore의 유저 상태를 업데이트합니다
+                self.updateUserStatus(from: state.userStatus, in: state.trainCar)
             }
             .store(in: &cancellables)
         /// 좌석 요청(자)  퍼블리셔
@@ -361,19 +353,21 @@ public final class MainFeatureViewModel: ViewModel {
                 guard let occupant = seat.occupant else { return }
                 // FIXME: - occupant 없을 시 방지
                 // FIXME: - 실제 seat의 occupant로 교체
-                if store.isBlocked && occupant.id != store.user.id {
-                    coordinator.push(AppScene.unlockSeatGuide) // 좌석 정보 잠금 해제 뷰
-                } else {
-                    coordinator.presentSheet( // 좌석 정보 조회
-                        AppSheet.seatInfo(
-                            occupant: occupant,
-                            reportButtonAction: {
-                                self.action(.reportButtonDidTap)
-                            },
-                            // FIXME: - 양보 로직 달기
-                            yieldButtonAction: { self.coordinator.dismissSheet() }
+                if occupant.id != store.user.id { // 내가 앉은 좌석에는 액션 적용 X
+                    if store.isBlocked {
+                        coordinator.push(AppScene.unlockSeatGuide) // 좌석 정보 잠금 해제 뷰
+                    } else {
+                        coordinator.presentSheet( // 좌석 정보 조회
+                            AppSheet.seatInfo(
+                                occupant: occupant,
+                                reportButtonAction: {
+                                    self.action(.reportButtonDidTap)
+                                },
+                                // FIXME: - 양보 로직 달기
+                                yieldButtonAction: { self.coordinator.dismissSheet() }
+                            )
                         )
-                    )
+                    }
                 }
             case .registering, .moving, .cancelling:
                 // 좌석을 선택합니다
@@ -400,20 +394,13 @@ public final class MainFeatureViewModel: ViewModel {
             do {
                 let trainCar = try await getSeatInTrainCarUseCase.execute(trainCode: currentTrainCode, carCode: currentCarCode)
                 await MainActor.run {
+                    state.trainCar = trainCar
                     guard state.trainCode == currentTrainCode,
                           state.carCode == currentCarCode else { return }
                     /// 현재 구역의 좌석 데이터만 필터링
                     state.seatSectionState.seats = getSeatInSectionUseCase.execute(trainCar: trainCar, seatSectionType: currentSeatSectionType)
-                    
-                    /// 나의 좌석 반영
-                    if let mySeat = findMySeat(in: trainCar) {
-                        state.mySeat = mySeat
-                        if state.userStatus == .standing {
-                            state.userStatus = .seated
-                            store.isSitting = true
-                        }
-                    }
-                    
+                    /// 유저 상태 업데이트
+                    self.updateUserStatus(from: state.userStatus, in: state.trainCar)
                     /// 나의 좌석 선택 처리 (좌석 등록 / 이동 시)
                     if currentUserStatus == .registering || currentUserStatus == .moving {
                         state.seatSectionState.selectedSeat = state.mySeat
@@ -441,13 +428,11 @@ public final class MainFeatureViewModel: ViewModel {
                 do {
                     let requesterPublisher = try await registerSeatUseCase.execute(seat)
                     self.store.subscribeToSeatRequesterPublisher(requesterPublisher, seatId: seat.id)
-                    state.userStatus = .seated // 상태 변경
-                    store.isSitting = true
+                    coordinator.push(AppScene.mainFeatureActionComplete(actionCase: .receivedCreditByRegister(creditAmount: 10))) // FIXME: 크레딧 액수 수정 필요
                 } catch {
                     print(error.localizedDescription)
                 }
             }
-            coordinator.popLast(2)
         }
     }
     
@@ -459,13 +444,11 @@ public final class MainFeatureViewModel: ViewModel {
                 do {
                     let requesterPublisher = try await moveSeatUseCase.execute(from: oldSeat, to: newSeat)
                     self.store.subscribeToSeatRequesterPublisher(requesterPublisher, seatId: newSeat.id)
-                    state.userStatus = .seated // 상태 변경
-                    store.isSitting = true
+                    coordinator.popLast(2)
                 } catch {
                     print(error.localizedDescription)
                 }
             }
-            coordinator.popLast(2)
         }
     }
     
@@ -476,14 +459,13 @@ public final class MainFeatureViewModel: ViewModel {
             Task {
                 do {
                     try await cancelSeatUseCase.execute(seat)
-                    state.userStatus = .standing // 상태 변경
-                    state.mySeat = nil
-                    store.isSitting = false
+                    // FIXME: 5분 내 취소한 경우에만 나타나도록 수정 필요
+                    // FIXME: 크레딧 액수 수정 필요
+                    coordinator.push(AppScene.mainFeatureActionComplete(actionCase: .takeBackCreditByCancel(creditAmount: 10)))
                 } catch {
                     print(error.localizedDescription)
                 }
             }
-            coordinator.popLast(2)
         }
     }
     
@@ -540,6 +522,42 @@ public final class MainFeatureViewModel: ViewModel {
                 } catch {
                     print(error.localizedDescription)
                 }
+            }
+        }
+    }
+    
+    @MainActor
+    private func updateUserStatus(from _status: UserStatus, in trainCar: TrainCar) {
+        switch _status {
+        case .registering, .moving, .cancelling: // 좌석 정보 등록, 이동, 취소
+            if let mySeat = self.findMySeat(in: trainCar) { // 해당 열차 내 착석 정보 조회
+                self.state.mySeat = mySeat
+                self.store.isSitting = true
+            } else {
+                self.state.mySeat = nil
+                self.store.isSitting = false
+            }
+        default: // 서 있거나 앉아 있을 때
+            /// 현재 보고 있는 구역 좌석 데이터입니다
+            let currentSection = Array(state.seatSectionState.seats.topSeats.values) + Array(state.seatSectionState.seats.bottomSeats.values)
+            /// 현재 보고 있는 구역 좌석 데이터입니다
+            if let mySeat = findMySeat(in: trainCar) {
+                if currentSection.contains(where: { $0.id == mySeat.id }) {
+                    /// mySeat가 현재 보고 있는 구역에 속하는 경우
+                    state.mySeat = mySeat
+                    state.userStatus = .seated
+                    store.isSitting = true
+                } else {
+                    /// mySeat가 현재 보고 있는 구역에 속하지 않는 경우
+                    state.mySeat = mySeat
+                    state.userStatus = .standing // 다른 구역에 내 자리가 있음
+                    store.isSitting = true
+                }
+            } else {
+                /// 좌석이 없으면 standing
+                state.mySeat = nil
+                state.userStatus = .standing
+                store.isSitting = false
             }
         }
     }

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/ManageSeat/ManageSeatViewModel.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/ManageSeat/ManageSeatViewModel.swift
@@ -64,10 +64,8 @@ public class ManageSeatViewModel: ViewModel {
         case .didSelectOption:
             if let option = state.selectedOption {
                 let scene = switch option {
-                case .register:
-                    AppScene.mainFeatureRegisterSeat
-                case .move:
-                    AppScene.mainFeatureMoveSeat
+                case .register, .move:
+                    store.isSitting ? AppScene.mainFeatureMoveSeat : AppScene.mainFeatureRegisterSeat
                 case .cancel:
                     AppScene.mainFeatureCancelSeat
                 }

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/UnlockSeat/UnlockSeatGuideView.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/UnlockSeat/UnlockSeatGuideView.swift
@@ -10,7 +10,7 @@ import SeatCatcherCore
 
 public struct UnlockSeatGuideView: View {
     
-    @State var viewModel: UnlockSeatGuideViewModel
+    @State private var viewModel: UnlockSeatGuideViewModel
     
     public init(viewModel: UnlockSeatGuideViewModel) {
         self._viewModel = State(initialValue: viewModel)

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/UnlockSeat/UnlockSeatGuideView.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/UnlockSeat/UnlockSeatGuideView.swift
@@ -1,0 +1,122 @@
+//
+//  UnlockSeatGuideView.swift
+//  SeatCatcherPresentation
+//
+//  Created by 황채웅 on 6/12/25.
+//
+
+import SwiftUI
+import SeatCatcherCore
+
+public struct UnlockSeatGuideView: View {
+    
+    @State var viewModel: UnlockSeatGuideViewModel
+    
+    public init(viewModel: UnlockSeatGuideViewModel) {
+        self._viewModel = State(initialValue: viewModel)
+    }
+    
+    public var body: some View {
+        VStack(alignment: .center, spacing: 0) {
+            VStack {
+                HStack(alignment: .center, spacing: 4) {
+                    Image(.catchy1)
+                        .resizable()
+                        .frame(width: 68, height: 68)
+                    VStack(alignment: .leading, spacing: 7) {
+                        Group {
+                            Text("신기한 발바닥")
+                                .font(.B03_M)
+                                .foregroundStyle(.gray300)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                            HStack(alignment: .center, spacing: 0) {
+                                Text("짐꾼")
+                                    .font(.B03_SB)
+                                    .foregroundStyle(.scGreen)
+                                    .padding(.horizontal, 10)
+                                    .frame(height: 28)
+                                    .background(.gray700)
+                                    .clipShape(.rect(cornerRadius: 6))
+                                    .padding(.trailing, 4)
+                                Text("장거리 이용객")
+                                    .font(.B03_SB)
+                                    .foregroundStyle(.scGreen)
+                                    .padding(.horizontal, 10)
+                                    .frame(height: 28)
+                                    .background(.gray700)
+                                    .clipShape(.rect(cornerRadius: 6))
+                                Spacer(minLength: 0)
+                            }
+                        }
+                    }
+                }
+                .padding(.bottom, 20)
+                HStack(alignment: .center, spacing: 6) {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("하차")
+                            .font(.B02_M)
+                            .foregroundStyle(.gray300)
+                        Text("하차까지")
+                            .font(.B02_M)
+                            .foregroundStyle(.gray300)
+                    }
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("상도역")
+                            .font(.B02_M)
+                            .foregroundStyle(.gray100)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        Text("30분 남았어요")
+                            .font(.B02_M)
+                            .foregroundStyle(.gray100)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+                .padding(.leading, 20)
+            }
+            .padding(.top, 20)
+            .padding(.horizontal, 20)
+            .padding(.bottom, 40)
+            .frame(width: 270, height: 200)
+            .background(.gray800)
+            .opacity(0.7)
+            .clipShape(.rect(cornerRadius: 30))
+            .padding(.top, 147)
+            Text("좌석정보 열람하고\n편안한 이동하기")
+                .multilineTextAlignment(.center)
+                .font(.T02_B)
+                .foregroundStyle(.gray100)
+                .padding(.top, 46)
+            Text("단 10 크레딧이면 빨리\n비워질 좌석을 확인할 수 있어요")
+                .multilineTextAlignment(.center)
+                .font(.B03_M)
+                .foregroundStyle(.gray300)
+                .padding(.top, 20)
+            Spacer(minLength: 0)
+            CTAButton(
+                title: "좌석정보 열람하기",
+                action: {
+                    viewModel.action(.unlockSeat)
+                },
+                style: .bottomEnabled
+            ).padding(.bottom, 11)
+            CTAButton(
+                title: "돌아가기",
+                action: {
+                    viewModel.action(.willDismiss)
+                },
+                style: .bottomMain
+            )
+            .padding(.bottom, 36)
+        }
+        .applyToolbarVisibility(.hidden, for: .navigationBar)
+        .padding(.horizontal, 18)
+        .ignoresSafeArea(edges: .bottom)
+        .background(
+            LinearGradient(
+                gradient: Gradient(colors: [.gray900, .grayGradient]),
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        )
+    }
+}

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/UnlockSeat/UnlockSeatGuideViewModel.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/UnlockSeat/UnlockSeatGuideViewModel.swift
@@ -39,7 +39,7 @@ public final class UnlockSeatGuideViewModel: ViewModel {
                 do {
                     try await unlockSeatUseCase.execute(creditAmount: 10, targetUserId: store.user.id) // FIXME: 크레딧 액수 수정
                     store.isBlocked = false
-                    coordinator.push(<#T##scene: any AppRoute##any AppRoute#>)
+                    coordinator.push(AppScene.mainFeatureActionComplete(actionCase: .unlockedSeat(creditAmount: 10)))
                 } catch {
                     print(error.localizedDescription)
                 }

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/UnlockSeat/UnlockSeatGuideViewModel.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/UnlockSeat/UnlockSeatGuideViewModel.swift
@@ -38,8 +38,10 @@ public final class UnlockSeatGuideViewModel: ViewModel {
             Task {
                 do {
                     try await unlockSeatUseCase.execute(creditAmount: 10, targetUserId: store.user.id) // FIXME: 크레딧 액수 수정
-                    store.isBlocked = false
-                    coordinator.push(AppScene.mainFeatureActionComplete(actionCase: .unlockedSeat(creditAmount: 10)))
+                    await MainActor.run {
+                        store.isBlocked = false
+                        coordinator.push(AppScene.mainFeatureActionComplete(actionCase: .unlockedSeat(creditAmount: 10)))
+                    }
                 } catch {
                     print(error.localizedDescription)
                 }

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/UnlockSeat/UnlockSeatGuideViewModel.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Flows/App/MainFeature/UnlockSeat/UnlockSeatGuideViewModel.swift
@@ -1,0 +1,51 @@
+//
+//  UnlockSeatGuideViewModel.swift
+//  SeatCatcherPresentation
+//
+//  Created by 황채웅 on 6/12/25.
+//
+
+import Foundation
+import SeatCatcherCore
+import SeatCatcherDomain
+
+@Observable
+public final class UnlockSeatGuideViewModel: ViewModel {
+    struct State { }
+    
+    enum Action {
+        case unlockSeat
+        case willDismiss
+    }
+    
+    private let store: AppStore
+    private let coordinator: Coordinator
+    
+    private let unlockSeatUseCase: UnlockSeatUseCase
+    
+    private(set) var state = State()
+    
+    public init(store: AppStore, coordinator: Coordinator, unlockSeatUseCase: UnlockSeatUseCase) {
+        self.store = store
+        self.coordinator = coordinator
+        self.unlockSeatUseCase = unlockSeatUseCase
+    }
+    
+    func action(_ action: Action) {
+        switch action {
+        case .unlockSeat:
+            /// 좌석 정보를 잠금 해제합니다
+            Task {
+                do {
+                    try await unlockSeatUseCase.execute(creditAmount: 10, targetUserId: store.user.id) // FIXME: 크레딧 액수 수정
+                    store.isBlocked = false
+                    coordinator.push(<#T##scene: any AppRoute##any AppRoute#>)
+                } catch {
+                    print(error.localizedDescription)
+                }
+            }
+        case .willDismiss:
+            coordinator.pop()
+        }
+    }
+}

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Literals/MainFeatureLiterals.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Literals/MainFeatureLiterals.swift
@@ -25,12 +25,12 @@ public enum MainFeatureLiterals {
         case cancelSeat = "앉은좌석 취소하기"
     }
     
-    static func getTitleText(seatSection: SeatSectionType, status: MainFeatureViewModel.UserStatus) -> (title: String, subtitle: String?) {
+    static func getTitleText(seatSection: SeatSectionType, status: MainFeatureViewModel.UserStatus, isBlocked: Bool) -> (title: String, subtitle: String?) {
         switch status {
         case .seated:
             return (title: seatSection.rawValue + "에서\n앉아 있어요", subtitle: nil)
         case .standing:
-            return (title: seatSection.rawValue + "에서\n원하는 좌석을 찾아보세요", subtitle: "빨리 비워지는 좌석일수록 밝아져요")
+            return (title: seatSection.rawValue + "에서\n원하는 좌석을 찾아보세요", subtitle: isBlocked ? "크레딧을 통해 좌석정보를 확인할 수 있어요" : "빨리 비워지는 좌석일수록 밝아져요")
         case .registering, .moving:
             return (title: seatSection.rawValue + "에서\n내가 앉은 좌석을 선택해주세요", subtitle: "허위 등록 시, 이용이 제한될 수 있습니다.")
         case .cancelling:

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Resources/Assets.xcassets/Colors/GrayScale/GrayGradient.colorset/Contents.json
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Resources/Assets.xcassets/Colors/GrayScale/GrayGradient.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x48",
+          "green" : "0x3D",
+          "red" : "0x37"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Resources/Assets.xcassets/Icons/icon_accept.imageset/Contents.json
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Resources/Assets.xcassets/Icons/icon_accept.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "icon_accept.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Resources/Assets.xcassets/Icons/icon_accept.imageset/icon_accept.svg
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Resources/Assets.xcassets/Icons/icon_accept.imageset/icon_accept.svg
@@ -1,0 +1,5 @@
+<svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="40" cy="40" r="40" fill="#81EBBB"/>
+<circle cx="40" cy="40" r="33" fill="#00C080"/>
+<path d="M26 38.4706L37.5714 50L53 29" stroke="white" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Resources/Assets.xcassets/Icons/icon_credit_minus.imageset/Contents.json
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Resources/Assets.xcassets/Icons/icon_credit_minus.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "icon_credit_minus.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Resources/Assets.xcassets/Icons/icon_credit_minus.imageset/icon_credit_minus.svg
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Resources/Assets.xcassets/Icons/icon_credit_minus.imageset/icon_credit_minus.svg
@@ -1,0 +1,8 @@
+<svg width="82" height="82" viewBox="0 0 82 82" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="37.5006" cy="44.5004" r="37.5006" fill="#00C080"/>
+<circle cx="37.4995" cy="44.4998" r="28.125" fill="#00C080" stroke="#A4F3D3" stroke-width="3.75001"/>
+<circle cx="37.5006" cy="44.5004" r="33.7506" stroke="#81EBBB" stroke-width="7.50002" stroke-dasharray="14.06 14.06"/>
+<path d="M46.72 51.5751C44.9961 53.587 42.6096 54.916 39.9914 55.3222C37.3733 55.7283 34.6963 55.1847 32.4439 53.7896C30.1916 52.3945 28.5124 50.2399 27.7097 47.715C26.9071 45.1901 27.0339 42.4614 28.0672 40.0218C29.1005 37.5822 30.9723 35.5926 33.3443 34.4123C35.7163 33.2321 38.4322 32.9391 41.0014 33.5863C43.5706 34.2335 45.8236 35.7781 47.3535 37.9412" stroke="#D9F5E9" stroke-width="4.68751" stroke-linecap="round"/>
+<circle cx="67" cy="15" r="14" fill="#D9F5E9" stroke="#202329" stroke-width="2"/>
+<path d="M61 15H73" stroke="#00C080" stroke-width="3.2" stroke-linecap="round"/>
+</svg>

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Resources/Assets.xcassets/Icons/icon_credit_plus.imageset/Contents.json
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Resources/Assets.xcassets/Icons/icon_credit_plus.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "icon_credit_plus.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Resources/Assets.xcassets/Icons/icon_credit_plus.imageset/icon_credit_plus.svg
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Resources/Assets.xcassets/Icons/icon_credit_plus.imageset/icon_credit_plus.svg
@@ -1,0 +1,9 @@
+<svg width="82" height="82" viewBox="0 0 82 82" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="37.5006" cy="44.5004" r="37.5006" fill="#00C080"/>
+<circle cx="37.4995" cy="44.4998" r="28.125" fill="#00C080" stroke="#A4F3D3" stroke-width="3.75001"/>
+<circle cx="37.5006" cy="44.5004" r="33.7506" stroke="#81EBBB" stroke-width="7.50002" stroke-dasharray="14.06 14.06"/>
+<path d="M46.72 51.5751C44.9961 53.587 42.6096 54.916 39.9914 55.3222C37.3733 55.7283 34.6963 55.1847 32.4439 53.7896C30.1916 52.3945 28.5124 50.2399 27.7097 47.715C26.9071 45.1901 27.0339 42.4614 28.0672 40.0218C29.1005 37.5822 30.9723 35.5926 33.3443 34.4123C35.7163 33.2321 38.4322 32.9391 41.0014 33.5863C43.5706 34.2335 45.8236 35.7781 47.3535 37.9412" stroke="#D9F5E9" stroke-width="4.68751" stroke-linecap="round"/>
+<circle cx="67" cy="15" r="14" fill="#D9F5E9" stroke="#202329" stroke-width="2"/>
+<path d="M61 15H73" stroke="#00C080" stroke-width="3.2" stroke-linecap="round"/>
+<path d="M67 9L67 21" stroke="#00C080" stroke-width="3.2" stroke-linecap="round"/>
+</svg>

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Resources/Assets.xcassets/Icons/icon_reject.imageset/Contents.json
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Resources/Assets.xcassets/Icons/icon_reject.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "icon_reject.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Resources/Assets.xcassets/Icons/icon_reject.imageset/icon_reject.svg
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Resources/Assets.xcassets/Icons/icon_reject.imageset/icon_reject.svg
@@ -1,0 +1,6 @@
+<svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="40" cy="40" r="40" fill="#81EBBB"/>
+<circle cx="40" cy="40" r="33" fill="#00C080"/>
+<path d="M28 53L52 27" stroke="white" stroke-width="5" stroke-linecap="round"/>
+<path d="M52 53L28 27" stroke="white" stroke-width="5" stroke-linecap="round"/>
+</svg>

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Route/AppRoute.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Route/AppRoute.swift
@@ -31,6 +31,7 @@ public enum AppScene: AppRoute {
     case mainFeatureCancelSeat
     case manageSeat
     case selectSeatSection
+    case unlockSeatGuide
 
     public var id: String {
         switch self {
@@ -51,6 +52,7 @@ public enum AppScene: AppRoute {
         case .mainFeatureCancelSeat: return "mainFeatureCancelSeat"
         case .manageSeat: return "manageSeat"
         case .selectSeatSection: return "selectSeatSection"
+        case .unlockSeatGuide: return "unlockSeatGuide"
         }
     }
 

--- a/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Route/AppRoute.swift
+++ b/SeatCatcherPresentation/Sources/SeatCatcherPresentation/Route/AppRoute.swift
@@ -32,6 +32,7 @@ public enum AppScene: AppRoute {
     case manageSeat
     case selectSeatSection
     case unlockSeatGuide
+    case mainFeatureActionComplete(actionCase: MainFeatureActionCompleteViewModel.MainFeatureActionCase)
 
     public var id: String {
         switch self {
@@ -53,6 +54,7 @@ public enum AppScene: AppRoute {
         case .manageSeat: return "manageSeat"
         case .selectSeatSection: return "selectSeatSection"
         case .unlockSeatGuide: return "unlockSeatGuide"
+        case .mainFeatureActionComplete: return "mainFeatureActionComplete"
         }
     }
 


### PR DESCRIPTION
## ✅ Description

### 메인피쳐 액션 완료 이후 뷰 구현 : `MainFeatureActionCompleteView`
- 좌석 등록
- 좌석 정보 해제
- 5분 내 취소
- 양보 요청 중
- 양보 요청 수락
- 양보 요청 거절
- 양보 이후 크레딧 전달
- 양보 크레딧 지급

위 경우에서 공통적으로 띄울 뷰를 구현하였습니다
  - 경우에 따라 pop 하는 path의 개수를 지정하였습니다(메인피쳐 뷰에서 pop 로직 뺐습니다)
  - 버튼이 있는 경우엔 버튼으로 dismiss, 없는 경우엔 배경을 탭하면 dismiss 되도록 하였습니다
  - 양보 요청 중 아이콘은 로티 애니메이션인데, 일단 danger아이콘으로 해놨고 나중에 로티 파일 전달받으면 수정할 예정입니다

### 홈 - 메인피쳐 `quickBoardingButtonTapped` 플로우 보완
기존엔 바로 메인피쳐 뷰만 띄웠는데, 구역 선택 창을 먼저 push해줘서 path 스택에 쌓이도록 하였습니다(영상 참고)

### 좌석 정보 해제 플로우 메인피쳐뷰에서 분리 및 UI, 엔드포인트 구현 : `UnlockSeatGuideView`
`UnlockSeatGuideViewModel`에서 `unlockAllSeatUseCase`를 구현하도록 하였습니다
좌석 해제 유즈케이스 테스트는 아직 안해봤으나 뷰 레이아웃은 테스트 했습니다
`unlockSeatUseCase.execute(creditAmount: 10, targetUserId: store.user.id)`
크레딧 차감이어서 -10 해야하지만 테스트하려고 일단 10 해놨습니다

### 구역 간 이동 시 UI 버그 수정
원인 : 다른 구역 정보를 받지만, 보고 있는 구역에 대해서만 `findMySeat()`가 수행됨
1. 일반구역 A에서 착석 -> 일반구역 C에서 둘러보는 경우 : "일반구역 C에서 앉아있어요"로 표기됨
2. 일반구역 A에서 착석 -> 다른 구역에서 좌석 이동하기 시도하는 경우 : 기존 좌석 찾지 못하여 이동 불가
3. 일반구역 A에서 착석 -> 다른 구역에서 좌석 등록하기 시도하는 경우 : 기존 좌석 상태가 제거되지 않아 등록 불가

해결 : `trainCar`와 `mySeat`를 `State`에 넣어 전체 좌석 정보와 나의 좌석 정보를 저장, `updateUserStatus`로 유저 상태 통합 관리
1. 일반구역 A에서 착석 -> 일반구역 C 둘러보는 경우 : "일반구역 C에서 좌석을 찾아보세요"로 표기됨
2. 일반구역 A에서 착석 -> 다른 구역에서 좌석 이동하기 시도하는 경우 : 기존 좌석 상태 `mySeat`로 관리, 이동 가능
3. 일반구역 A에서 착석 -> 다른 구역에서 좌석 등록하기 시도하는 경우 : 좌석 등록/이동 선택 여부와 상관 없이 `state.isSitting`을 통해 코디네이터 push 로직 분기처리

#### `updateUserStatus`: 열차 정보 업데이트 되었을 때 매번 실행
- `state.mySeat` : 모든 열차 내 나의 좌석 정보
- `store.isSitting` : 모든 열차 내 나의 좌석 정보가 있는지 여부
- `state.userStatus` : 메인피쳐 뷰 분기처리에 사용(좌석 등록/이동/취소/서있음/앉아있음)

#### A : 착석한 상태(해당 열차 모든 구역 내)
- 1 : 해당 구역 내 좌석 정보가 있을 때
  - "(구역 명)에서 앉아있어요"
- 2 : 해당 구역 내 좌석 정보가 없을 때 (앉아있지만 다른 구역 둘러보는 경우)
  - "(구역 명)에서 자리를 찾아보세요"
#### B : 착석하지 않은 상태
  - "(구역 명)에서 자리를 찾아보세요"


## ⭐️ PR Point
<!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
- 양보 로직은 메인피쳐 뷰 state에 있는 `Requestee`, `Requester` 사용해서 구현해주시면 됩니다
- 유저가 크레딧 액수를 설정하게 되는 양보 플로우를 제외한 크레딧 사용처의 경우(좌석 5분 내 취소, 좌석 등록) 리터럴로 액수를 관리할 필요가 있습니다

## 📸 Simulator
잠금 해제 뷰는 다른 폰이 없어서 테스트를 못했습니다

https://github.com/user-attachments/assets/19423c3b-e6a4-4f89-8929-3dfe3354e0d9


## 💡 Issue
- Resolved: #70 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 좌석 정보 잠금 해제 가이드 화면과 완료 화면이 추가되었습니다.
  - 좌석 잠금 해제 시 크레딧 차감 및 관련 UI 안내가 도입되었습니다.
  - 좌석 잠금 해제, 크레딧 송금/취소 등 주요 액션 완료 시 결과 화면이 제공됩니다.

- **UI 개선**
  - 내 좌석은 잠금 상태여도 차단 표시가 되지 않도록 시각적 표시가 개선되었습니다.
  - 좌석 관련 안내 문구와 버튼, 아이콘(승인/거절/크레딧 증감 등)이 추가되었습니다.
  - 특정 상황에서 안내 문구가 크레딧 안내로 변경됩니다.

- **버그 수정**
  - 좌석 선택 및 상태 갱신 로직이 개선되어 사용자 상태가 보다 정확히 반영됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->